### PR TITLE
enable multiarch support

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -8,9 +8,12 @@ buildArgs=()
 if [ -n "${CODENAME:-}" ]; then
 	buildArgs+=( '--codename-copy' )
 fi
+if [ -n "${ARCH:-}" ]; then
+	buildArgs+=( "--dpkg-arch=${ARCH}" )
+fi
 buildArgs+=( travis "$SUITE" "@$epoch" )
 
-checkFile="travis/$serial/amd64/${CODENAME:-$SUITE}/rootfs.tar.xz"
+checkFile="travis/$serial/${ARCH:=amd64}/${CODENAME:-$SUITE}/rootfs.tar.xz"
 
 set -x
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: bash
 services: docker
 
+addons:
+    apt:
+        packages:
+            - binfmt-support
+            - qemu-user-static
+
 env:
     - SUITE=jessie   CODENAME=        TIMESTAMP=2017-01-01T00:00:00Z SHA256=a674379d30cf457e49a909bb0e254ddcb1f72c27f45c68fe930668d6d9399232
+    - SUITE=jessie   CODENAME=        TIMESTAMP=2017-01-01T00:00:00Z SHA256=e1aa8ecfffc78e0239131ccd46f8a9e03c08084eeb30738b738c284c5197f0a9 ARCH=arm64
     - SUITE=stable   CODENAME=jessie  TIMESTAMP=2017-01-01T00:00:00Z SHA256=a674379d30cf457e49a909bb0e254ddcb1f72c27f45c68fe930668d6d9399232
     - SUITE=stretch  CODENAME=        TIMESTAMP=2017-01-01T00:00:00Z SHA256=139ed970d52ef950c223f9ab325657eb93d0a93c7d6e2fc697fe7510e61760fa
     - SUITE=testing  CODENAME=stretch TIMESTAMP=2017-01-01T00:00:00Z SHA256=139ed970d52ef950c223f9ab325657eb93d0a93c7d6e2fc697fe7510e61760fa

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM debian:stretch-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		debootstrap \
+		qemu-user-static \
 		xz-utils \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/scripts/.tar-exclude
+++ b/scripts/.tar-exclude
@@ -1,6 +1,9 @@
 # the file we store the "epoch" of a given rootfs in
 ./debuerreotype-epoch
 
+# qemu user static binary
+./usr/bin/qemu-*-static
+
 # "/dev" is a special case in "debuerreotype-tar"
 #./dev/**
 ./proc/**

--- a/scripts/debuerreotype-gen-sources-list
+++ b/scripts/debuerreotype-gen-sources-list
@@ -24,6 +24,7 @@ secmirror="${1:-}"; shift || eusage 'missing secmirror'
 [ -n "$targetDir" ]
 
 comp='main'
+dpkgArch=$(debuerreotype-chroot "$targetDir" dpkg --print-architecture)
 
 deb() {
 	echo "deb $*"
@@ -33,17 +34,12 @@ deb() {
 }
 
 # https://github.com/tianon/go-aptsources/blob/e066ed9cd8cd9eef7198765bd00ec99679e6d0be/target.go#L16-L58
-{
-	case "$suite" in
-		sid|unstable|testing)
-			deb "$mirror" "$suite" "$comp"
-			;;
-
-		*)
-			deb "$mirror" "$suite" "$comp"
-			deb "$mirror" "$suite-updates" "$comp"
-			deb "$secmirror" "$suite/updates" "$comp"
-			;;
-	esac
-} > "$targetDir/etc/apt/sources.list"
+deb "$mirror" "$suite" "$comp" > "$targetDir/etc/apt/sources.list"
+# https://github.com/moby/moby/blob/master/contrib/mkimage/debootstrap#L195
+if wget --quiet --spider "$mirror/dists/$suite-updates/main/binary-$dpkgArch/Packages.gz"; then
+  deb "$mirror" "$suite-updates" "$comp" >> "$targetDir/etc/apt/sources.list"
+fi
+if wget --quiet --spider "$secmirror/dists/$suite/updates/main/binary-$dpkgArch/Packages.gz"; then
+  deb "$secmirror" "$suite/updates" "$comp" >> "$targetDir/etc/apt/sources.list"
+fi
 chmod 0644 "$targetDir/etc/apt/sources.list"

--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -3,8 +3,19 @@ set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
-	'<target-dir> <suite> <timestamp>' \
+	'[--arch=<dpkgArch>] <target-dir> <suite> <timestamp>' \
 	'rootfs stretch 2017-05-08T00:00:00Z'
+
+options="$(getopt -n "$self" -o '' --long 'arch:' -- "$@")" || eusage
+eval "set -- $options"
+arch=
+while true; do
+	flag="$1"; shift
+	case "$flag" in
+		--arch) arch="$1"; shift ;;
+		--) break ;;
+	esac
+done
 
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
 suite="${1:-}"; shift || eusage 'missing suite'
@@ -22,10 +33,14 @@ export SOURCE_DATE_EPOCH="$epoch"
 mirror="$("$thisDir/.snapshot-url.sh" "@$epoch")"
 secmirror="$("$thisDir/.snapshot-url.sh" "@$epoch" 'debian-security')"
 
-debootstrap \
+# allow for DEBOOTSTRAP=qemu-debootstrap debuerreotype-init ...
+: ${DEBOOTSTRAP:=debootstrap}
+
+${DEBOOTSTRAP} \
 	--force-check-gpg \
 	--merged-usr \
 	--variant=minbase \
+	${arch:+--arch=$arch} \
 	"$suite" "$targetDir" "$mirror"
 echo "$epoch" > "$targetDir/debuerreotype-epoch"
 


### PR DESCRIPTION
debuerreotype is meant to create base Debian images, but it takes an existing foreign-arched Debian image to build a native debuerreotype docker image itself. Therefore this patch allows cross building foreign-arched Debian images with one same debuerreotype docker image on a amd64 environment.

Prerequisite package __qemu-user-static__ will be installed in debuerreotype docker image, which then grows to ~150MB.