### PR TITLE
Update slimify exclusion logic to match dpkg's internal behavior better

### DIFF
--- a/scripts/debuerreotype-slimify
+++ b/scripts/debuerreotype-slimify
@@ -37,17 +37,25 @@ for slimExclude in "${slimExcludes[@]}"; do
 	if [[ "$slimExclude" == *'/*' ]]; then
 		if [ -d "$targetDir/$(dirname "$slimExclude")" ]; then
 			# use two passes so that we don't fail trying to remove directories from $neverExclude
+			# this is our best effort at implementing https://sources.debian.net/src/dpkg/stretch/src/filters.c/#L96-L97 in shell
+
+			# step 1 -- delete everything that doesn't match "$neverExclude" and isn't a directory or a symlink
 			"$thisDir/debuerreotype-chroot" "$targetDir" \
 				find "$(dirname "$slimExclude")" \
 					-mindepth 1 \
 					-not -path "$neverExclude" \
-					-not -type d \
+					-not \( -type d -o -type l \) \
 					-delete
-			"$thisDir/debuerreotype-chroot" "$targetDir" \
-				find "$(dirname "$slimExclude")" \
-					-mindepth 1 \
-					-empty \
-					-delete
+
+			# step 2 -- repeatedly delete any dangling symlinks and empty directories until there aren't any
+			# (might have a dangling symlink in a directory which then makes it empty, or a symlink to an empty directory)
+			while [ "$(
+				"$thisDir/debuerreotype-chroot" "$targetDir" \
+					find "$(dirname "$slimExclude")" \
+						-mindepth 1 \( -empty -o -xtype l \) \
+						-delete -printf '.' \
+					| wc -c
+			)" -gt 0 ]; do true; done
 		fi
 	else
 		"$thisDir/debuerreotype-chroot" "$targetDir" rm -f "$slimExclude"


### PR DESCRIPTION
Namely, the following policy edge case: (https://www.debian.org/doc/debian-policy/ch-docs.html#s-copyrightfile)

> /usr/share/doc/package may be a symbolic link to another directory in /usr/share/doc only if the two packages both come from the same source and the first package Depends on the second. These rules are important because copyright files must be extractable by mechanical means.

And the following in `dpkg(1)`: (https://manpages.debian.org/stretch/dpkg/dpkg.1.en.html)

> Note: the current implementation might re-include more directories and symlinks than needed, to be on the safe side and avoid possible unpack failures; future work might fix this.

See https://github.com/debuerreotype/docker-debian-artifacts/issues/10.