### PR TITLE
Refactor and normalize getopt for consistent UX

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -13,30 +13,21 @@ suites=(
 )
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
-self="$(basename "$0")"
+source "$thisDir/scripts/.constants.sh" \
+	--flags 'no-build' \
+	-- \
+	'[--no-build] <output-dir> <timestamp>' \
+	'output 2017-05-08T00:00:00Z'
 
-usage() {
-	cat <<-EOU
-		usage: $self <output-dir> <timestamp>
-		   ie: $self output 2017-05-08T00:00:00Z
-	EOU
-}
-eusage() {
-	if [ "$#" -gt 0 ]; then
-		echo >&2 "error: $*"
-	fi
-	usage >&2
-	exit 1
-}
-
-options="$(getopt -n "$self" -o '' --long 'no-build' -- "$@")" || eusage
-eval "set -- $options"
+eval "$dgetopt"
 build=1
 while true; do
 	flag="$1"; shift
+	dgetopt-case "$flag"
 	case "$flag" in
 		--no-build) build= ;; # for skipping "docker build"
 		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
 	esac
 done
 

--- a/build.sh
+++ b/build.sh
@@ -2,33 +2,24 @@
 set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
-self="$(basename "$0")"
+source "$thisDir/scripts/.constants.sh" \
+	--flags 'no-build,codename-copy' \
+	-- \
+	'[--no-build] [--codename-copy] <output-dir> <suite> <timestamp>' \
+	'output stretch 2017-05-08T00:00:00Z
+--codename-copy output stable 2017-05-08T00:00:00Z'
 
-usage() {
-	cat <<-EOU
-		usage: $self <output-dir> <suite> <timestamp>
-		   ie: $self output stretch 2017-05-08T00:00:00Z
-		       $self --codename-copy output stable 2017-05-08T00:00:00Z
-	EOU
-}
-eusage() {
-	if [ "$#" -gt 0 ]; then
-		echo >&2 "error: $*"
-	fi
-	usage >&2
-	exit 1
-}
-
-options="$(getopt -n "$self" -o '' --long 'no-build,codename-copy' -- "$@")" || eusage
-eval "set -- $options"
+eval "$dgetopt"
 build=1
 codenameCopy=
 while true; do
 	flag="$1"; shift
+	dgetopt-case "$flag"
 	case "$flag" in
 		--no-build) build= ;; # for skipping "docker build"
 		--codename-copy) codenameCopy=1 ;; # for copying a "stable.tar.xz" to "stretch.tar.xz" with updated sources.list (saves a lot of extra building work)
 		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
 	esac
 done
 

--- a/scripts/.constants.sh
+++ b/scripts/.constants.sh
@@ -4,6 +4,43 @@
 export TZ='UTC' LC_ALL='C'
 umask 0002
 scriptsDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+self="$(basename "$0")"
+
+options="$(getopt -n "$BASH_SOURCE" -o '+' --long 'flags:,flags-short:' -- "$@")"
+dFlags=
+dFlagsShort=
+usageStr=
+__cgetopt() {
+	eval "set -- $options" # in a function since otherwise "set" will overwrite the parent script's positional args too
+	unset options
+
+	while true; do
+		local flag="$1"; shift
+		case "$flag" in
+			--flags) dFlags="$1"; shift ;;
+			--flags-short) dFlagsShort="$1"; shift ;;
+			--) break ;;
+			*) echo >&2 "error: unexpected $BASH_SOURCE flag '$flag'"; exit 1 ;;
+		esac
+	done
+
+	while [ "$#" -gt 0 ]; do
+		local IFS=$'\n'
+		local usagePrefix='usage:' usageLine=
+		for usageLine in $1; do
+			usageStr+="$usagePrefix $self${usageLine:+ $usageLine}"$'\n'
+			usagePrefix='      '
+		done
+		usagePrefix='   ie:'
+		for usageLine in $2; do
+			usageStr+="$usagePrefix $self${usageLine:+ $usageLine}"$'\n'
+			usagePrefix='      '
+		done
+		usageStr+=$'\n'
+		shift 2
+	done
+}
+__cgetopt
 
 _version() {
 	local v
@@ -19,22 +56,32 @@ _version() {
 	echo "$v"
 }
 
-usageStr="$1"
-usageEx="$2"
-self="$(basename "$0")"
 usage() {
-	local v="$(_version)"
-	cat <<-EOU
-		usage: $self $usageStr
-		   ie: $self $usageEx
+	echo -n "$usageStr"
 
-		debuerreotype version $v
-	EOU
+	local v="$(_version)"
+	echo "debuerreotype version $v"
 }
 eusage() {
 	if [ "$#" -gt 0 ]; then
-		echo >&2 "error: $*"
+		echo >&2 "error: $*"$'\n'
 	fi
 	usage >&2
 	exit 1
+}
+_dgetopt() {
+	getopt -n "$self" \
+		-o "+h?${dFlagsShort}" \
+		--long "help,version${dFlags:+,$dFlags}" \
+		-- "$@" \
+		|| eusage 'getopt failed'
+}
+dgetopt='options="$(_dgetopt "$@")"; eval "set -- $options"; unset options'
+dgetopt-case() {
+	local flag="$1"; shift
+
+	case "$flag" in
+		-h|'-?'|--help) usage; exit 0 ;;
+		--version) _version; exit 0 ;;
+	esac
 }

--- a/scripts/debuerreotype-apt-get
+++ b/scripts/debuerreotype-apt-get
@@ -6,6 +6,16 @@ source "$thisDir/.constants.sh" \
 	'<target-dir> arguments' \
 	'rootfs update'
 
+eval "$dgetopt"
+while true; do
+	flag="$1"; shift
+	dgetopt-case "$flag"
+	case "$flag" in
+		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
+	esac
+done
+
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
 [ -n "$targetDir" ]
 

--- a/scripts/debuerreotype-chroot
+++ b/scripts/debuerreotype-chroot
@@ -6,6 +6,16 @@ source "$thisDir/.constants.sh" \
 	'<target-dir> <command> [args...]' \
 	'rootfs apt-get update'
 
+eval "$dgetopt"
+while true; do
+	flag="$1"; shift
+	dgetopt-case "$flag"
+	case "$flag" in
+		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
+	esac
+done
+
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
 cmd="${1:-}"; shift || eusage 'missing command'
 [ -n "$targetDir" ]

--- a/scripts/debuerreotype-fixup
+++ b/scripts/debuerreotype-fixup
@@ -6,6 +6,16 @@ source "$thisDir/.constants.sh" \
 	'<target-dir>' \
 	'rootfs'
 
+eval "$dgetopt"
+while true; do
+	flag="$1"; shift
+	dgetopt-case "$flag"
+	case "$flag" in
+		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
+	esac
+done
+
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
 [ -n "$targetDir" ]
 epoch="$(< "$targetDir/debuerreotype-epoch")"

--- a/scripts/debuerreotype-gen-sources-list
+++ b/scripts/debuerreotype-gen-sources-list
@@ -3,17 +3,20 @@ set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
+	--flags 'deb-src' \
+	-- \
 	'[--deb-src] <target-dir> <suite> <mirror> <secmirror>' \
 	'rootfs stretch http://deb.debian.org/debian http://security.debian.org'
 
-options="$(getopt -n "$self" -o '' --long 'deb-src' -- "$@")" || eusage
-eval "set -- $options"
+eval "$dgetopt"
 debSrc=
 while true; do
 	flag="$1"; shift
+	dgetopt-case "$flag"
 	case "$flag" in
 		--deb-src) debSrc=1 ;;
 		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
 	esac
 done
 

--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -6,6 +6,16 @@ source "$thisDir/.constants.sh" \
 	'<target-dir> <suite> <timestamp>' \
 	'rootfs stretch 2017-05-08T00:00:00Z'
 
+eval "$dgetopt"
+while true; do
+	flag="$1"; shift
+	dgetopt-case "$flag"
+	case "$flag" in
+		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
+	esac
+done
+
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
 suite="${1:-}"; shift || eusage 'missing suite'
 timestamp="${1:-}"; shift || eusage 'missing timestamp'

--- a/scripts/debuerreotype-minimizing-config
+++ b/scripts/debuerreotype-minimizing-config
@@ -6,6 +6,16 @@ source "$thisDir/.constants.sh" \
 	'<target-dir>' \
 	'rootfs'
 
+eval "$dgetopt"
+while true; do
+	flag="$1"; shift
+	dgetopt-case "$flag"
+	case "$flag" in
+		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
+	esac
+done
+
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
 [ -n "$targetDir" ]
 

--- a/scripts/debuerreotype-slimify
+++ b/scripts/debuerreotype-slimify
@@ -6,6 +6,16 @@ source "$thisDir/.constants.sh" \
 	'<target-dir>' \
 	'rootfs'
 
+eval "$dgetopt"
+while true; do
+	flag="$1"; shift
+	dgetopt-case "$flag"
+	case "$flag" in
+		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
+	esac
+done
+
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
 [ -n "$targetDir" ]
 

--- a/scripts/debuerreotype-tar
+++ b/scripts/debuerreotype-tar
@@ -3,17 +3,20 @@ set -Eeuo pipefail
 
 thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
+	--flags 'include-dev' \
+	-- \
 	'[--include-dev] <target-dir> <target-tar>' \
 	'rootfs rootfs.tar'
 
-options="$(getopt -n "$self" -o '' --long 'include-dev' -- "$@")" || eusage
-eval "set -- $options"
+eval "$dgetopt"
 includeDev=
 while true; do
 	flag="$1"; shift
+	dgetopt-case "$flag"
 	case "$flag" in
 		--include-dev) includeDev=1 ;;
 		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
 	esac
 done
 

--- a/scripts/debuerreotype-version
+++ b/scripts/debuerreotype-version
@@ -6,4 +6,14 @@ source "$thisDir/.constants.sh" \
 	'' \
 	''
 
+eval "$dgetopt"
+while true; do
+	flag="$1"; shift
+	dgetopt-case "$flag"
+	case "$flag" in
+		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
+	esac
+done
+
 _version


### PR DESCRIPTION
This makes all our commands respond to `--help`, `-h`, `-?`, and `--version` consistently and cleanly.