### PR TITLE
Apply "--no-merged-usr" to all released suites in "build.sh"

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -51,13 +51,19 @@ echo "-- BUILDING TARBALLS FOR '$dpkgArch' FROM '$mirror/' --"
 echo
 
 for suite in "${suites[@]}"; do
-	testUrl="$secmirror/dists/$suite/updates/main/binary-$dpkgArch/Packages.gz"
+	doSkip=
 	case "$suite" in
-		testing|unstable)
-			testUrl="$mirror/dists/$suite/main/binary-$dpkgArch/Packages.gz"
+		testing|unstable) ;;
+		*)
+			if ! wget --quiet --spider "$secmirror/dists/$suite/updates/main/binary-$dpkgArch/Packages.gz"; then
+				doSkip=1
+			fi
 			;;
 	esac
-	if ! wget --quiet --spider "$testUrl"; then
+	if ! wget --quiet --spider "$mirror/dists/$suite/main/binary-$dpkgArch/Packages.gz"; then
+		doSkip=1
+	fi
+	if [ -n "$doSkip" ]; then
 		echo >&2
 		echo >&2 "warning: '$suite' not supported on '$dpkgArch' (at '$timestamp'); skipping"
 		echo >&2

--- a/build.sh
+++ b/build.sh
@@ -103,7 +103,16 @@ docker run \
 		fi
 
 		{
-			debuerreotype-init rootfs "$suite" "@$epoch"
+			initArgs=( --debian )
+			releaseSuite="$(awk -F ": " "\$1 == \"Suite\" { print \$2; exit }" "$outputDir/Release")"
+			case "$suite" in
+				# see https://bugs.debian.org/src:usrmerge for why merged-usr should not be in stable yet (mostly "dpkg" related bugs)
+				*oldstable|stable)
+					initArgs+=( --no-merged-usr )
+					;;
+			esac
+
+			debuerreotype-init "${initArgs[@]}" rootfs "$suite" "@$epoch"
 
 			debuerreotype-minimizing-config rootfs
 			debuerreotype-apt-get rootfs update -qq


### PR DESCRIPTION
See https://github.com/debuerreotype/docker-debian-artifacts/issues/12#issuecomment-327192735.

The TL;DR is that it was great to apply `--merged-usr` to `stretch` while it was still `testing`, but now that it's `stable` and there are still `dpkg` bugs that aren't fixed, it doesn't make sense to apply in `stable`.  We'll revisit this when `buster` gets closer to release (hopefully with `dpkg` updates to make it moot, but I'm not holding my breath).