### PR TITLE
Add "rootfs.debuerreotype-version" file to "build.sh" output

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 **
+
+!VERSION
 !scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		gnupg dirmngr \
 	&& rm -rf /var/lib/apt/lists/*
 
-COPY scripts /opt/debuerreotype/scripts
+# see ".dockerignore"
+COPY . /opt/debuerreotype
 RUN set -ex; \
 	cd /opt/debuerreotype/scripts; \
 	for f in debuerreotype-*; do \
 		ln -svL "$PWD/$f" "/usr/local/bin/$f"; \
-	done
+	done; \
+	version="$(debuerreotype-version)"; \
+	[ "$version" != 'unknown' ]; \
+	echo "debuerreotype version $version"
 
 WORKDIR /tmp
 

--- a/build.sh
+++ b/build.sh
@@ -265,7 +265,8 @@ docker run \
 					fi
 				" > "$targetBase.manifest"
 				echo "$epoch" > "$targetBase.debuerreotype-epoch"
-				touch_epoch "$targetBase.manifest" "$targetBase.debuerreotype-epoch"
+				debuerreotype-version > "$targetBase.debuerreotype-version"
+				touch_epoch "$targetBase.manifest" "$targetBase.debuerreotype-epoch" "$targetBase.debuerreotype-version"
 
 				for f in debian_version os-release apt/sources.list; do
 					targetFile="$targetBase.$(basename "$f" | sed -r "s/[^a-zA-Z0-9_-]+/-/g")"


### PR DESCRIPTION
(Which also fixes `debuerreotype-version` to work properly inside the built image by including `VERSION` in the image.)