### PR TITLE
Fix "targetDir" permissions causing minor reproducibility issue

### DIFF
--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -165,6 +165,10 @@ chmod 0644 \
 	"$targetDir/etc/machine-id" \
 	"$targetDir/etc/resolv.conf"
 
+# fix ownership/permissions on / (otherwise "debootstrap" leaves them as-is which causes reproducibility issues)
+chown 0:0 "$targetDir"
+chmod 0755 "$targetDir"
+
 # https://bugs.debian.org/857803
 # adjust field 3 in /etc/shadow and /etc/shadow- to $(( epoch / 60 / 60 / 24 )), if it's larger
 sp_lstchg="$(( epoch / 60 / 60 / 24 ))"


### PR DESCRIPTION
While trying to chase down a failure in Debian's `autopkgtest` I discovered this fun little edge case.

If I have `debuerreotype` create a directory locally, the permissions on that directory are `0755`, but if I use `mktemp -d`, they're `0700`, which gets embedded in the result of `debuerreotype-tar` as an entry for `./`, which causes the hash to change. :man_facepalming:

(Turns out the same is true of the ownership on that directory.)