### PR TITLE
Fix over-enthusiastic /usr/share/lintian excludes

### DIFF
--- a/scripts/.slimify-excludes
+++ b/scripts/.slimify-excludes
@@ -5,6 +5,6 @@
 /usr/share/groff/*
 /usr/share/info/*
 /usr/share/linda/*
-/usr/share/lintian/*
+/usr/share/lintian/overrides/*
 /usr/share/locale/*
 /usr/share/man/*


### PR DESCRIPTION
`<nthykier> tianon: the root of the issue is that "/usr/share/lintian/*" is excluded (breaking lintian).  The correct exclude would be "/usr/share/lintian/overrides/*"`

Thanks @nthykier :heart: