### PR TITLE
Properly apply --merged-usr / --no-merged-usr

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -153,7 +153,7 @@ docker run \
 			initArgs+=( --keyring "$keyring" )
 
 			releaseSuite="$(awk -F ": " "\$1 == \"Suite\" { print \$2; exit }" "$outputDir/Release")"
-			case "$suite" in
+			case "$releaseSuite" in
 				# see https://bugs.debian.org/src:usrmerge for why merged-usr should not be in stable yet (mostly "dpkg" related bugs)
 				*oldstable|stable)
 					initArgs+=( --no-merged-usr )

--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -102,7 +102,7 @@ if [ -n "$minbaseSupported" ]; then
 	debootstrapArgs+=( --variant=minbase )
 fi
 
-[ -n "$noMergedUsr" ] || debootstrapArgs+=( --merged-usr )
+[ -n "$noMergedUsr" ] && debootstrapArgs+=( --no-merged-usr ) || debootstrapArgs+=( --merged-usr )
 [ -z "$keyring" ] || debootstrapArgs+=( --keyring="$keyring" )
 [ -z "$arch" ] || debootstrapArgs+=( --arch="$arch" )
 [ -z "$include" ] || debootstrapArgs+=( --include="$include" )


### PR DESCRIPTION
This is important given that merged-usr may or may not be enabled for us by default at the debootstrap layer in the future (this also fixes a bug in "build.sh" where we incorrectly detected "stable" suites).