### PR TITLE
Update slimify with more excludes and more includes from src:localepurge

### DIFF
--- a/scripts/.slimify-excludes
+++ b/scripts/.slimify-excludes
@@ -1,5 +1,6 @@
 #   This file contains the list of files/directories which will be removed for "slim" image variants.
 #  https://github.com/tianon/docker-brew-debian/issues/48
+
 # https://wiki.ubuntu.com/ReducingDiskFootprint#Drop_unnecessary_files
 /usr/share/doc/*
 /usr/share/groff/*
@@ -8,3 +9,11 @@
 /usr/share/lintian/overrides/*
 /usr/share/locale/*
 /usr/share/man/*
+
+# https://anonscm.debian.org/cgit/collab-maint/localepurge.git/tree/usr/share/localepurge/gen-dpkg-cfg.pl?id=b32c8d46d43be2027096f5a202ac789a637ceb39#n9
+/usr/share/locale/*
+/usr/share/gnome/help/*/*
+/usr/share/doc/kde/HTML/*/*
+/usr/share/omf/*/*-*.emf
+
+# see also .slimify-includes

--- a/scripts/.slimify-includes
+++ b/scripts/.slimify-includes
@@ -1,0 +1,17 @@
+#   This file contains the list of files/directories which will *NOT* be removed for "slim" image variants.
+#  https://github.com/tianon/docker-brew-debian/issues/48
+
+# https://wiki.ubuntu.com/ReducingDiskFootprint#Drop_unnecessary_files
+/usr/share/doc/*/copyright
+
+# https://anonscm.debian.org/cgit/collab-maint/localepurge.git/tree/usr/share/localepurge/gen-dpkg-cfg.pl?id=b32c8d46d43be2027096f5a202ac789a637ceb39#n9
+/usr/share/locale/locale.alias
+/usr/share/gnome/help/*/C/*
+/usr/share/doc/kde/HTML/C/*
+/usr/share/omf/*/*-C.emf
+/usr/share/locale/languages'
+/usr/share/locale/all_languages'
+/usr/share/locale/currency/*'
+/usr/share/locale/l10n/*
+
+# see also .slimify-excludes

--- a/scripts/debuerreotype-slimify
+++ b/scripts/debuerreotype-slimify
@@ -21,6 +21,7 @@ targetDir="${1:-}"; shift || eusage 'missing target-dir'
 
 IFS=$'\n'; set -o noglob
 slimExcludes=( $(grep -vE '^#|^$' "$thisDir/.slimify-excludes" | sort -u) )
+slimIncludes=( $(grep -vE '^#|^$' "$thisDir/.slimify-includes" | sort -u) )
 set +o noglob; unset IFS
 
 dpkgCfgFile="$targetDir/etc/dpkg/dpkg.cfg.d/docker"
@@ -31,7 +32,13 @@ mkdir -p "$(dirname "$dpkgCfgFile")"
 	echo '# and this configuration file keeps them that way.'
 } > "$dpkgCfgFile"
 
-neverExclude='/usr/share/doc/*/copyright'
+findMatchIncludes=()
+for slimInclude in "${slimIncludes[@]}"; do
+	[ "${#findMatchIncludes[@]}" -eq 0 ] || findMatchIncludes+=( '-o' )
+	findMatchIncludes+=( -path "$slimInclude" )
+done
+findMatchIncludes=( '(' "${findMatchIncludes[@]}" ')' )
+
 for slimExclude in "${slimExcludes[@]}"; do
 	{
 		echo
@@ -46,14 +53,14 @@ for slimExclude in "${slimExcludes[@]}"; do
 
 	if [[ "$slimExclude" == *'/*' ]]; then
 		if [ -d "$targetDir/$(dirname "$slimExclude")" ]; then
-			# use two passes so that we don't fail trying to remove directories from $neverExclude
+			# use two passes so that we don't fail trying to remove directories from $slimIncludes
 			# this is our best effort at implementing https://sources.debian.net/src/dpkg/stretch/src/filters.c/#L96-L97 in shell
 
-			# step 1 -- delete everything that doesn't match "$neverExclude" and isn't a directory or a symlink
+			# step 1 -- delete everything that doesn't match "$slimIncludes" and isn't a directory or a symlink
 			"$thisDir/debuerreotype-chroot" "$targetDir" \
 				find "$(dirname "$slimExclude")" \
 					-depth -mindepth 1 \
-					-not -path "$neverExclude" \
+					-not "${findMatchIncludes[@]}" \
 					-not \( -type d -o -type l \) \
 					-exec rm -f '{}' ';'
 
@@ -73,7 +80,8 @@ for slimExclude in "${slimExcludes[@]}"; do
 done
 {
 	echo
-	echo '# always include these files, especially for license compliance'
-	echo "path-include $neverExclude"
+	for slimInclude in "${slimIncludes[@]}"; do
+		echo "path-include $slimInclude"
+	done
 } >> "$dpkgCfgFile"
 chmod 0644 "$dpkgCfgFile"


### PR DESCRIPTION
See https://anonscm.debian.org/cgit/collab-maint/localepurge.git/tree/usr/share/localepurge/gen-dpkg-cfg.pl?id=b32c8d46d43be2027096f5a202ac789a637ceb39#n9

Once again, thanks @nthykier! :heart:

Here's an example `diffoscope` of this change in the current tarballs: (including both #32 and #34 as well, since that's what I've got tarballs for handy for diffing against)

```diff
 |#######################################################################################################################################################################################|  100%                             Time: 0:00:05 
--- rootfs.tar.xz
+++ output/20180426/amd64/stretch/slim/rootfs.tar.xz
├── rootfs.tar
│ ├── file list
│ │ @@ -120,15 +120,15 @@
│ │  -rw-r--r--   0        0        0      657 2017-03-22 09:43:33.000000 etc/default/hwclock
│ │  -rw-r--r--   0        0        0     1756 2018-01-14 10:39:44.000000 etc/default/nss
│ │  -rw-r--r--   0        0        0     1118 2017-05-17 11:59:59.000000 etc/default/useradd
│ │  -rw-r--r--   0        0        0      604 2016-06-26 20:00:56.000000 etc/deluser.conf
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 etc/dpkg/
│ │  -rw-r--r--   0        0        0      446 2014-11-28 01:08:21.000000 etc/dpkg/dpkg.cfg
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 etc/dpkg/dpkg.cfg.d/
│ │ --rw-r--r--   0        0        0     2806 2018-04-26 00:00:00.000000 etc/dpkg/dpkg.cfg.d/docker
│ │ +-rw-r--r--   0        0        0     3543 2018-04-26 00:00:00.000000 etc/dpkg/dpkg.cfg.d/docker
│ │  -rw-r--r--   0        0        0      259 2018-04-26 00:00:00.000000 etc/dpkg/dpkg.cfg.d/docker-apt-speedup
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 etc/dpkg/origins/
│ │  -rw-r--r--   0        0        0       82 2009-02-02 23:06:58.000000 etc/dpkg/origins/debian
│ │  lrwxrwxrwx   0        0        0        0 2018-04-26 00:00:00.000000 etc/dpkg/origins/default -> debian
│ │  -rw-r--r--   0        0        0        0 2018-04-26 00:00:00.000000 etc/environment
│ │  -rw-r--r--   0        0        0       37 2018-04-26 00:00:00.000000 etc/fstab
│ │  -rw-r--r--   0        0        0     2584 2016-08-02 02:01:36.000000 etc/gai.conf
│ │ @@ -457,16 +457,14 @@
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 opt/
│ │  drwxr-xr-x   0        0        0        0 2018-02-23 23:23:00.000000 proc/
│ │  drwx------   0        0        0        0 2018-04-26 00:00:00.000000 root/
│ │  -rw-r--r--   0        0        0      570 2010-01-31 11:52:26.000000 root/.bashrc
│ │  -rw-r--r--   0        0        0      148 2015-08-17 15:30:33.000000 root/.profile
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 run/
│ │  drwxrwxrwt   0        0        0        0 2018-04-26 00:00:00.000000 run/lock/
│ │ -drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 run/mount/
│ │ --rw-r--r--   0        0        0        0 2018-04-26 00:00:00.000000 run/mount/utab
│ │  -rw-rw-r--   0        0        0        0 2018-04-26 00:00:00.000000 run/utmp
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 sbin/
│ │  -rwxr-xr-x   0        0        0    57680 2018-03-07 18:29:09.000000 sbin/agetty
│ │  -rwxr-xr-x   0        0        0    26632 2017-02-01 00:54:55.000000 sbin/badblocks
│ │  -rwxr-xr-x   0        0        0    27264 2018-03-07 18:29:09.000000 sbin/blkdiscard
│ │  -rwxr-xr-x   0        0        0    85408 2018-03-07 18:29:09.000000 sbin/blkid
│ │  -rwxr-xr-x   0        0        0    35624 2018-03-07 18:29:09.000000 sbin/blockdev
│ │ @@ -2079,15 +2077,16 @@
│ │  -rw-r--r--   0        0        0     2389 2018-02-14 16:53:20.000000 usr/share/gdb/auto-load/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.22-gdb.py
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 usr/share/info/
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 usr/share/keyrings/
│ │  -rw-r--r--   0        0        0    36941 2017-05-25 18:17:13.000000 usr/share/keyrings/debian-archive-keyring.gpg
│ │  -rw-r--r--   0        0        0    17538 2017-05-25 18:17:13.000000 usr/share/keyrings/debian-archive-removed-keys.gpg
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 usr/share/libc-bin/
│ │  -rw-r--r--   0        0        0      497 2017-12-31 12:12:42.000000 usr/share/libc-bin/nsswitch.conf
│ │ -drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 usr/share/lintian/
│ │ +drwxr-xr-x   0        0        0        0 2018-02-23 23:23:00.000000 usr/share/lintian/
│ │ +drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 usr/share/lintian/overrides/
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 usr/share/locale/
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 usr/share/man/
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 usr/share/menu/
│ │  -rw-r--r--   0        0        0      194 2013-10-23 12:41:22.000000 usr/share/menu/bash
│ │  -rw-r--r--   0        0        0      108 2017-01-24 05:16:56.000000 usr/share/menu/dash
│ │  drwxr-xr-x   0        0        0        0 2018-02-23 23:23:00.000000 usr/share/misc/
│ │  drwxr-xr-x   0        0        0        0 2018-04-26 00:00:00.000000 usr/share/pam/
│ ├── etc/dpkg/dpkg.cfg.d/docker
│ │ @@ -16,32 +16,40 @@
│ │  #  libsepol1:amd64 libsmartcols1:amd64 libss2:amd64 libstdc++6:amd64 
│ │  #  libsystemd0:amd64 libtinfo5:amd64 libudev1:amd64 libustr-1.0-1:amd64 
│ │  #  libuuid1:amd64 login lsb-base mawk mount multiarch-support ncurses-base 
│ │  #  ncurses-bin passwd perl-base sed sensible-utils sysvinit-utils tar tzdata 
│ │  #  util-linux zlib1g:amd64
│ │  path-exclude /usr/share/doc/*
│ │  
│ │ +# dpkg -S '/usr/share/doc/kde/HTML/*/*'
│ │ +#  dpkg-query: no path found matching pattern /usr/share/doc/kde/HTML/*/*
│ │ +path-exclude /usr/share/doc/kde/HTML/*/*
│ │ +
│ │ +# dpkg -S '/usr/share/gnome/help/*/*'
│ │ +#  dpkg-query: no path found matching pattern /usr/share/gnome/help/*/*
│ │ +path-exclude /usr/share/gnome/help/*/*
│ │ +
│ │  # dpkg -S '/usr/share/groff/*'
│ │  #  dpkg-query: no path found matching pattern /usr/share/groff/*
│ │  path-exclude /usr/share/groff/*
│ │  
│ │  # dpkg -S '/usr/share/info/*'
│ │  #  coreutils diffutils findutils grep gzip sed
│ │  path-exclude /usr/share/info/*
│ │  
│ │  # dpkg -S '/usr/share/linda/*'
│ │  #  dpkg-query: no path found matching pattern /usr/share/linda/*
│ │  path-exclude /usr/share/linda/*
│ │  
│ │ -# dpkg -S '/usr/share/lintian/*'
│ │ -#  apt base-files base-passwd bash bsdutils debconf dpkg gzip 
│ │ -#  init-system-helpers libc-bin libc6:amd64 libdb5.3:amd64 libgcc1:amd64 
│ │ -#  libpam-modules-bin libpam-modules:amd64 libpam-runtime libpam0g:amd64 login 
│ │ -#  mount ncurses-base passwd perl-base util-linux
│ │ -path-exclude /usr/share/lintian/*
│ │ +# dpkg -S '/usr/share/lintian/overrides/*'
│ │ +#  apt base-files base-passwd bash bsdutils debconf dpkg init-system-helpers 
│ │ +#  libc-bin libc6:amd64 libdb5.3:amd64 libgcc1:amd64 libpam-modules-bin 
│ │ +#  libpam-modules:amd64 libpam-runtime libpam0g:amd64 login mount ncurses-base 
│ │ +#  passwd perl-base util-linux
│ │ +path-exclude /usr/share/lintian/overrides/*
│ │  
│ │  # dpkg -S '/usr/share/locale/*'
│ │  #  adduser apt bash coreutils diffutils dpkg e2fsprogs findutils grep 
│ │  #  libapt-pkg5.0:amd64 libgpg-error0:amd64 libpam-runtime login sed tar
│ │  path-exclude /usr/share/locale/*
│ │  
│ │  # dpkg -S '/usr/share/man/*'
│ │ @@ -49,9 +57,20 @@
│ │  #  diffutils diversion by dash from diversion by dash to dpkg e2fsprogs 
│ │  #  findutils gpgv grep gzip hostname init-system-helpers libaudit-common 
│ │  #  libc-bin libpam-modules-bin libpam-modules:amd64 libpam-runtime 
│ │  #  libpcre3:amd64 libsemanage-common login mawk mount ncurses-bin passwd 
│ │  #  perl-base sed sensible-utils sysvinit-utils tar util-linux
│ │  path-exclude /usr/share/man/*
│ │  
│ │ -# always include these files, especially for license compliance
│ │ +# dpkg -S '/usr/share/omf/*/*-*.emf'
│ │ +#  dpkg-query: no path found matching pattern /usr/share/omf/*/*-*.emf
│ │ +path-exclude /usr/share/omf/*/*-*.emf
│ │ +
│ │  path-include /usr/share/doc/*/copyright
│ │ +path-include /usr/share/doc/kde/HTML/C/*
│ │ +path-include /usr/share/gnome/help/*/C/*
│ │ +path-include /usr/share/locale/all_languages'
│ │ +path-include /usr/share/locale/currency/*'
│ │ +path-include /usr/share/locale/l10n/*
│ │ +path-include /usr/share/locale/languages'
│ │ +path-include /usr/share/locale/locale.alias
│ │ +path-include /usr/share/omf/*/*-C.emf
```