### PR TITLE
Tweak a bit to ensure we're still good when updating our Dockerfile to be FROM buster (newer debootstrap)

### DIFF
--- a/scripts/.tar-exclude
+++ b/scripts/.tar-exclude
@@ -23,6 +23,9 @@
 # see https://github.com/debuerreotype/debuerreotype/issues/7
 ./etc/apt/trustdb.gpg
 
+# a wheezy-only file which only shows up when building via debootstrap in buster+ for some reason
+./run/shm/.run-transition
+
 # Debian creates this file reproducibly, but Ubuntu does not
 # (according to "man 1 journalctl", this is automatically recreated by "journalctl --update-catalog")
 # Tails also removes this file to achieve reproducibility (https://labs.riseup.net/code/projects/tails/repository/revisions/b1e05c8aac12fc79293f6a220b40a538d4f38c51/diff/config/chroot_local-hooks/99-zzzzzz_reproducible-builds-post-processing)


### PR DESCRIPTION
- more aggressive keyring handling (buster's got wheezy's key relegated to the removed-keys keyring now, for example)
- exclude "/run/shm/.run-transition" (which only shows up when building with buster+ debootstrap, for some reason -- possibly related to ischroot/mount differences?)