### PR TITLE
Fix manifest file generation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -256,7 +256,7 @@ docker run \
 				touch_epoch "$targetBase.tar.xz.sha256"
 
 				debuerreotype-chroot "$rootfs" bash -c "
-					if ! dpkg-query -W &> /dev/null; then
+					if ! dpkg-query -W 2> /dev/null; then
 						# --debian-eol woody has no dpkg-query
 						dpkg -l
 					fi


### PR DESCRIPTION
Fixes minor regression in #55 (`rootfs.manifest` files were completely empty, which is obviously pretty useless).

Discovered at https://github.com/docker-library/official-images/pull/5486#issuecomment-468472624 (thanks @yosifkit). :+1: