### PR TITLE
Add workaround for EOL suites with expired GPG keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ env:
     - SUITE=wheezy    CODENAME=       TIMESTAMP=2017-01-01T00:00:00Z SHA256=f1bd72548e3c25ce222fb9e2bb57a5b6d4b01042180894fb05d83a0251e6dab1
     # EOL suites testing
     - SUITE=eol CODENAME=etch            TIMESTAMP=2017-01-01T00:00:00Z SHA256=eb005e297101b8e4555a08e96395fa0575cbdddf4901a081948b17a4039939bd
-    - SUITE=eol CODENAME=woody ARCH=i386 TIMESTAMP=2017-01-01T00:00:00Z SHA256=46a1330121271abd01e107a886b7f85ce72edb0ae9fdf9c139562dc0fba806b1
+    - SUITE=eol CODENAME=lenny           TIMESTAMP=2017-01-01T00:00:00Z SHA256=6bcd3bfe6916dcf6e4f923d8eddcb41105fc8c0d002765fbca7d9f95e346019e
+    - SUITE=eol CODENAME=woody ARCH=i386 TIMESTAMP=2017-01-01T00:00:00Z SHA256=a1457a071c39bd0c54755a27430475896dd1623a743a7d34c6a1b951a4aaea0a
     # qemu-debootstrap testing
     - ARCH=arm64 SUITE=jessie CODENAME= TIMESTAMP=2017-01-01T00:00:00Z SHA256=893efc1b9db1ba2df4f171d4422194a408f9810d3b55d9b0cd66fcc7722f7567
     # a few entries for "today" to try and catch issues like https://github.com/debuerreotype/debuerreotype/issues/41 sooner

--- a/scripts/.fix-apt-comments.sh
+++ b/scripts/.fix-apt-comments.sh
@@ -21,10 +21,8 @@ aptVersion="${1:-}"; shift || eusage 'missing apt-version'
 
 # support for "apt.conf" comments of the style "# xxx" was added in 0.7.22
 # (https://salsa.debian.org/apt-team/apt/commit/81e9789b12374073e848c73c79e235f82c14df44)
-case "$aptVersion" in
-	0.7.22* | 0.7.23* | 0.7.24* | 0.7.25* | 0.8* | 0.9*) exit ;;
-	0.*) ;; # anything lower than 0.7.22 needs fixing
-	*) exit ;; # anything else is good
-esac
+if dpkg --compare-versions "$aptVersion" '>=' '0.7.22~'; then
+	exit
+fi
 
 sed -ri -e 's!^#!//!' "$@"

--- a/scripts/.gpgv-ignore-expiration.sh
+++ b/scripts/.gpgv-ignore-expiration.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -Eeu
+
+# For the sake of EOL releases (whose archive keys have often expired), we need a fake "gpgv" substitute that will essentially ignore *just* key expiration.
+# (So we get *some* signature validation instead of using something like "--allow-unauthenticated" or "--force-yes" which disable security entirely instead.)
+
+# Intended usage (APT >= 1.1):
+#   apt-get -o Apt::Key::gpgvcommand=/.../.debuerreotype-gpgv-ignore-expiration ...
+# or (APT < 1.1):
+#   apt-get -o Dir::Bin::gpg=/.../.debuerreotype-gpgv-ignore-expiration ...
+# (https://salsa.debian.org/apt-team/apt/commit/12841e8320aa499554ac50b102b222900bb1b879)
+
+# Functionally, this script will scrape "--status-fd" (which is the only way a user of "gpgv" can care about / process expired key metadata) and MITM "gpgv" to replace EXPKEYSIG with GOODSIG instead.
+
+_status_fd() {
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+			--status-fd)
+				echo "$2"
+				return 0
+				;;
+		esac
+		shift
+	done
+	return 1
+}
+
+if fd="$(_status_fd "$@")" && [ -n "$fd" ]; then
+	# older bash (3.2, lenny) doesn't support variable file descriptors (hence "eval")
+	# (bash: syntax error near unexpected token `$fd')
+	eval 'exec gpgv "$@" '"$fd"'> >(sed "s/EXPKEYSIG/GOODSIG/" >&'"$fd"')'
+fi
+
+# no "--status-fd"? no worries! ("gpgv" without "--status-fd" doesn't seem to care about expired keys, so we don't have to either)
+exec gpgv "$@"

--- a/scripts/debuerreotype-gpgv-ignore-expiration-config
+++ b/scripts/debuerreotype-gpgv-ignore-expiration-config
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+source "$thisDir/.constants.sh" \
+	'<target-dir>' \
+	'rootfs'
+
+eval "$dgetopt"
+while true; do
+	flag="$1"; shift
+	dgetopt-case "$flag"
+	case "$flag" in
+		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
+	esac
+done
+
+targetDir="${1:-}"; shift || eusage 'missing target-dir'
+[ -n "$targetDir" ]
+
+aptVersion="$("$thisDir/.apt-version.sh" "$targetDir")"
+# if we're on APT 0.6 or lower, this isn't relevant
+# (added in 0.7.21 / 0.7.20.2+lenny1; https://salsa.debian.org/apt-team/apt/commit/0b77f4775db7bc45964e0337b8978a170b3f0483)
+if dpkg --compare-versions "$aptVersion" '<<' '0.7.20~'; then
+	echo >&2 "note: skipping $self: APT version ($aptVersion) too old to be relevant"
+	exit
+fi
+
+sourceFile="$thisDir/.gpgv-ignore-expiration.sh"
+targetPath='/usr/local/bin/.debuerreotype-gpgv-ignore-expiration'
+targetFile="$targetDir$targetPath"
+cp -T "$sourceFile" "$targetFile"
+chmod 0755 "$targetFile"
+
+# APT 1.1+ changed to use "apt-key verify" instead of invoking "gpgv" directly
+# (https://salsa.debian.org/apt-team/apt/commit/12841e8320aa499554ac50b102b222900bb1b879)
+aptConfigKey='Apt::Key::gpgvcommand'
+case "$aptVersion" in
+	0.* | 1.0*) aptConfigKey='Dir::Bin::gpg' ;;
+esac
+
+cat > "$targetDir/etc/apt/apt.conf.d/debuerreotype-gpgv-ignore-expiration" <<-EOF
+	# For the sake of EOL releases (whose archive keys have often expired), we need
+	# a fake "gpgv" substitute that will essentially ignore *just* key expiration.
+	# (So we get *some* signature validation instead of using something like
+	# "--allow-unauthenticated" or "--force-yes" which disable security entirely
+	# instead.)
+
+	$aptConfigKey "$targetPath";
+EOF
+chmod 0644 "$targetDir/etc/apt/apt.conf.d/debuerreotype-gpgv-ignore-expiration"
+"$thisDir/.fix-apt-comments.sh" "$aptVersion" "$targetDir/etc/apt/apt.conf.d/debuerreotype-gpgv-ignore-expiration"

--- a/scripts/debuerreotype-minimizing-config
+++ b/scripts/debuerreotype-minimizing-config
@@ -57,6 +57,9 @@ if [ -d "$targetDir/etc/dpkg/dpkg.cfg.d" ]; then
 fi
 
 if [ -d "$targetDir/etc/apt/apt.conf.d" ]; then
+	# TODO make some (all?) of these conditional based on the version of APT that added the feature
+	# (perhaps it's finally time for an "apt-version-cmp.sh" helper script to test whether APT is X or newer one version component at a time? "dpkg --compare-versions"!!!)
+
 	# update "autoremove" configuration to be aggressive about removing suggests deps that weren't manually installed
 	cat > "$targetDir/etc/apt/apt.conf.d/docker-autoremove-suggests" <<-'EOF'
 		# Since Docker users are looking for the smallest possible final images, the


### PR DESCRIPTION
For the sake of EOL releases (whose archive keys have often expired), we need a fake `gpgv` substitute that will essentially ignore *just* key expiration.

(So we get *some* signature validation instead of using something like `--allow-unauthenticated` or `--force-yes` which disable security entirely instead.)

This workaround *only* gets applied when we're doing an EOL build, and only when the APT version is new enough to need it (older APT versions didn't verify that).

This is the last bits needed in `debuerreotype` itself to finally take care of https://github.com/debuerreotype/docker-debian-artifacts/issues/65.  With this, I have successfully verified the full reproducibility of `woody`/3.0 through `wheezy`/7.0 across two days across `i386`, `arm`, `armel`, `armhf`, and `amd64` as applicable.