### PR TITLE
Also exclude "/var/state/apt" appropriately for old APT versions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -259,6 +259,16 @@ docker run \
 						# woody not only contains "exim", but launches it during our build process and tries to email "root@debuerreotype" (which fails and creates non-reproducibility)
 						tarArgs+=( --exclude ./var/spool/exim --exclude ./var/log/exim )
 						;;
+
+					potato)
+						tarArgs+=(
+							# for some reason, pototo leaves a core dump (TODO figure out why??)
+							--exclude "./core"
+							--exclude "./qemu*.core"
+							# also, it leaves some junk in /tmp (/tmp/fdmount.conf.tmp.XXX)
+							--exclude "./tmp/fdmount.conf.tmp.*"
+						)
+						;;
 				esac
 
 				debuerreotype-tar "${tarArgs[@]}" "$rootfs" "$targetBase.tar.xz"

--- a/scripts/.tar-exclude
+++ b/scripts/.tar-exclude
@@ -14,6 +14,10 @@
 ./var/lib/apt/lists/*Packages*
 ./var/lib/apt/lists/*Release*
 ./var/lib/apt/lists/lock
+# https://salsa.debian.org/apt-team/apt/commit/5555ef9850b7e66aa02d39bb7d624fdf3e43edb2 (APT 0.9.14 removed support for /var/state/apt)
+./var/state/apt/lists/*Packages*
+./var/state/apt/lists/*Release*
+./var/state/apt/lists/lock
 
 # ends up with host-kernel info
 ./etc/apt/apt.conf.d/01autoremove-kernels
@@ -36,8 +40,3 @@
 # (according to "man 1 journalctl", this is automatically recreated by "journalctl --update-catalog")
 # Tails also removes this file to achieve reproducibility (https://labs.riseup.net/code/projects/tails/repository/revisions/b1e05c8aac12fc79293f6a220b40a538d4f38c51/diff/config/chroot_local-hooks/99-zzzzzz_reproducible-builds-post-processing)
 ./var/lib/systemd/catalog/database
-
-# for some reason, pototo leaves a core dump (TODO figure out why??)
-./core
-# also, it leaves some junk in /tmp (/tmp/fdmount.conf.tmp.XXX)
-./tmp/fdmount.conf.tmp.*

--- a/scripts/debuerreotype-tar
+++ b/scripts/debuerreotype-tar
@@ -38,7 +38,9 @@ if dpkg --compare-versions "$aptVersion" '>=' '0.8~'; then
 	excludes+=(
 		'./var/cache/apt/**'
 		'./var/lib/apt/lists/**'
+		'./var/state/apt/lists/**'
 	)
+	# (see also the targeted exclusions in ".tar-exclude" that these are overriding)
 fi
 
 "$thisDir/debuerreotype-fixup" "$targetDir"


### PR DESCRIPTION
See https://salsa.debian.org/apt-team/apt/commit/5555ef9850b7e66aa02d39bb7d624fdf3e43edb2 (APT 0.9.14 removed the final bit of support for `/var/state/apt`).

This also moves the Potato-specific additional exclusions into `build.sh` so that they only get applied to Potato.