### PR TITLE
Update Travis to use Bionic instead of Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: bash
 services: docker
 


### PR DESCRIPTION
This doesn't help us test `riscv64` (#70), but it does seem prudent regardless given Trusty's age and impending EOL.