### PR TITLE
Fix travis build failing due to undefined variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
     - ARCH=sh4     SUITE=unstable CODENAME= TIMESTAMP=2019-01-01T00:00:00Z SHA256=c6bbc35292a0f2d9e3db8a1db3a1925b7d02affbd61a46b8bbc798d6710419db
     #- ARCH=riscv64 SUITE=unstable CODENAME= TIMESTAMP=2019-09-18T00:00:00Z SHA256=bed905d70debcd02879f67b647554951338e8a9bbc41e8067583ace9b3cc457e
     # a few entries for "today" to try and catch issues like https://github.com/debuerreotype/debuerreotype/issues/41 sooner
-    - SUITE=unstable  CODENAME= TIMESTAMP="today 00:00:00" SHA256=
-    - SUITE=stable    CODENAME= TIMESTAMP="today 00:00:00" SHA256=
-    - SUITE=oldstable CODENAME= TIMESTAMP="today 00:00:00" SHA256=
+    - SUITE=unstable  CODENAME="" TIMESTAMP="today 00:00:00" SHA256=""
+    - SUITE=stable    CODENAME="" TIMESTAMP="today 00:00:00" SHA256=""
+    - SUITE=oldstable CODENAME="" TIMESTAMP="today 00:00:00" SHA256=""
 
 addons:
     apt:


### PR DESCRIPTION
We use a couple empty but defined variables in the `env` section of the
build definition. They seem to not be forwarded as such to the build
script anymore, which it expects and so fails.

Try using the `VAR=""` notation to fix the issue.