### PR TITLE
Add new slimify bits from localepurge 0.7.3.9

### DIFF
--- a/scripts/.slimify-excludes
+++ b/scripts/.slimify-excludes
@@ -10,11 +10,10 @@
 /usr/share/locale/*
 /usr/share/man/*
 
-# https://salsa.debian.org/elmig-guest/localepurge/-/blob/2608425c05b75c9c65d04ba12f099eb9eab51e35/usr/share/localepurge/gen-dpkg-cfg.pl#L9-21
+# https://salsa.debian.org/elmig-guest/localepurge/-/blob/176446028ca719d65993eb01e39d7040fbbcf12d/usr/share/localepurge/gen-dpkg-cfg.pl#L9-20
 /usr/share/doc/kde/HTML/*/*
 /usr/share/gnome/help/*/*
 /usr/share/locale/*
 /usr/share/omf/*/*-*.emf
-/usr/share/X11/locale/*
 
 # see also .slimify-includes

--- a/scripts/.slimify-excludes
+++ b/scripts/.slimify-excludes
@@ -10,10 +10,11 @@
 /usr/share/locale/*
 /usr/share/man/*
 
-# https://salsa.debian.org/elmig-guest/localepurge/blob/9899763213226f293a29c0ebd2be2e45aace01ee/usr/share/localepurge/gen-dpkg-cfg.pl#L9-20
-/usr/share/locale/*
-/usr/share/gnome/help/*/*
+# https://salsa.debian.org/elmig-guest/localepurge/-/blob/2608425c05b75c9c65d04ba12f099eb9eab51e35/usr/share/localepurge/gen-dpkg-cfg.pl#L9-21
 /usr/share/doc/kde/HTML/*/*
+/usr/share/gnome/help/*/*
+/usr/share/locale/*
 /usr/share/omf/*/*-*.emf
+/usr/share/X11/locale/*
 
 # see also .slimify-includes

--- a/scripts/.slimify-includes
+++ b/scripts/.slimify-includes
@@ -4,7 +4,7 @@
 # https://wiki.ubuntu.com/ReducingDiskFootprint#Drop_unnecessary_files
 /usr/share/doc/*/copyright
 
-# https://salsa.debian.org/elmig-guest/localepurge/-/blob/2608425c05b75c9c65d04ba12f099eb9eab51e35/usr/share/localepurge/gen-dpkg-cfg.pl#L22-49
+# https://salsa.debian.org/elmig-guest/localepurge/-/blob/176446028ca719d65993eb01e39d7040fbbcf12d/usr/share/localepurge/gen-dpkg-cfg.pl#L22-47
 /usr/share/doc/kde/HTML/C/*
 /usr/share/gnome/help/*/C/*
 /usr/share/locale/all_languages
@@ -13,9 +13,5 @@
 /usr/share/locale/languages
 /usr/share/locale/locale.alias
 /usr/share/omf/*/*-C.emf
-/usr/share/X11/locale/C/*
-/usr/share/X11/locale/compose.dir
-/usr/share/X11/locale/locale.alias
-/usr/share/X11/locale/locale.dir
 
 # see also .slimify-excludes

--- a/scripts/.slimify-includes
+++ b/scripts/.slimify-includes
@@ -4,14 +4,18 @@
 # https://wiki.ubuntu.com/ReducingDiskFootprint#Drop_unnecessary_files
 /usr/share/doc/*/copyright
 
-# https://salsa.debian.org/elmig-guest/localepurge/blob/9899763213226f293a29c0ebd2be2e45aace01ee/usr/share/localepurge/gen-dpkg-cfg.pl#L21-47
-/usr/share/locale/locale.alias
-/usr/share/gnome/help/*/C/*
+# https://salsa.debian.org/elmig-guest/localepurge/-/blob/2608425c05b75c9c65d04ba12f099eb9eab51e35/usr/share/localepurge/gen-dpkg-cfg.pl#L22-49
 /usr/share/doc/kde/HTML/C/*
-/usr/share/omf/*/*-C.emf
-/usr/share/locale/languages
+/usr/share/gnome/help/*/C/*
 /usr/share/locale/all_languages
 /usr/share/locale/currency/*
 /usr/share/locale/l10n/*
+/usr/share/locale/languages
+/usr/share/locale/locale.alias
+/usr/share/omf/*/*-C.emf
+/usr/share/X11/locale/C/*
+/usr/share/X11/locale/compose.dir
+/usr/share/X11/locale/locale.alias
+/usr/share/X11/locale/locale.dir
 
 # see also .slimify-excludes


### PR DESCRIPTION
These come from reviewing the following localepurge diff:

https://salsa.debian.org/elmig-guest/localepurge/-/compare/9899763213226f293a29c0ebd2be2e45aace01ee...2608425c05b75c9c65d04ba12f099eb9eab51e35?w=1#dc5bce24f8152e7a979333f0ad4e46acae10e6c6

(Ignoring bits we had ignored previously, like vim files, and now sorting the lines case insensitively so they're easier to maintain/review.)

We should probably re-review the ones we've skipped and add some note here as to why we've done so, and we should probably expand all the `localepurge` references to `@LOCALE@` to both `C` and `C.UTF-8` so that those two generic locales remain usable in "slimified" images.