### PR TITLE
Include the "-removed" keyring for ports too

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -132,7 +132,8 @@ docker run \
 
 			if [ -n "$ports" ]; then
 				gpg --batch --no-default-keyring --keyring "$keyring" --import \
-					/usr/share/keyrings/debian-ports-archive-keyring.gpg
+					/usr/share/keyrings/debian-ports-archive-keyring.gpg \
+					/usr/share/keyrings/debian-ports-archive-keyring-removed.gpg
 			fi
 		fi
 


### PR DESCRIPTION
We include the `-removed` keyring for the normal archive, and we need to do the same for ports (for the same reasons).