### PR TITLE
Remove "ping" and "ip" from Debian 11+

### DIFF
--- a/examples/debian.sh
+++ b/examples/debian.sh
@@ -205,18 +205,22 @@ if [ -n "$sbuild" ]; then
 	tar -cC "$rootfsDir" . | tar -xC "$rootfsDir"-sbuild
 fi
 
-# prefer iproute2 if it exists
-iproute=iproute2
-if ! debuerreotype-apt-get "$rootfsDir" install -qq -s iproute2 &> /dev/null; then
-	# poor wheezy
-	iproute=iproute
+# for historical reasons (related to their usefulness in debugging non-working container networking in container early days before "--network container:xxx"), Debian 10 and older non-slim images included both "ping" and "ip" above "minbase", but in 11+ (Bullseye), that will no longer be the case and we will instead be a faithful minbase again :D
+epoch2021="$(date --date '2021-01-01 00:00:00' +%s)"
+if [ "$epoch" -lt "$epoch2021" ] || { isDebianBusterOrOlder="$([ -f "$rootfsDir/etc/os-release" ] && source "$rootfsDir/etc/os-release" && [ -n "${VERSION_ID:-}" ] && [ "${VERSION_ID%%.*}" -le 10 ] && echo 1)" && [ -n "$isDebianBusterOrOlder" ]; }; then
+	# prefer iproute2 if it exists
+	iproute=iproute2
+	if ! debuerreotype-apt-get "$rootfsDir" install -qq -s iproute2 &> /dev/null; then
+		# poor wheezy
+		iproute=iproute
+	fi
+	ping=iputils-ping
+	if debuerreotype-chroot "$rootfsDir" bash -c 'command -v ping > /dev/null'; then
+		# if we already have "ping" (as in --debian-eol potato), skip installing any extra ping package
+		ping=
+	fi
+	debuerreotype-apt-get "$rootfsDir" install -y $noInstallRecommends $ping $iproute
 fi
-ping=iputils-ping
-if debuerreotype-chroot "$rootfsDir" bash -c 'command -v ping > /dev/null'; then
-	# if we already have "ping" (as in --debian-eol potato), skip installing any extra ping package
-	ping=
-fi
-debuerreotype-apt-get "$rootfsDir" install -y $noInstallRecommends $ping $iproute
 
 debuerreotype-slimify "$rootfsDir"-slim
 


### PR DESCRIPTION
For historical reasons (related to their usefulness in debugging non-working container networking in container early days before `--network container:xxx`), Debian 10 and older non-slim images included both `ping` and `ip` above `minbase`, but in 11+ (Bullseye), that will no longer be the case and we will instead be a faithful minbase again 😄