### PR TITLE
Add "-v" to all "readlink" invocations

### DIFF
--- a/.docker-image.sh
+++ b/.docker-image.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(readlink -f "$BASH_SOURCE")"
+thisDir="$(readlink -vf "$BASH_SOURCE")"
 thisDir="$(dirname "$thisDir")"
 
 ver="$("$thisDir/scripts/debuerreotype-version")"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 # usage: mkdir -p output && ./run-script.sh ./examples/debian.sh output ...
 
-thisDir="$(readlink -f "$BASH_SOURCE")"
+thisDir="$(readlink -vf "$BASH_SOURCE")"
 thisDir="$(dirname "$thisDir")"
 
 source "$thisDir/scripts/.constants.sh" \

--- a/examples/debian-all.sh
+++ b/examples/debian-all.sh
@@ -13,7 +13,7 @@ suites=(
 )
 
 debuerreotypeScriptsDir="$(which debuerreotype-init)"
-debuerreotypeScriptsDir="$(readlink -f "$debuerreotypeScriptsDir")"
+debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
 debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
 
 source "$debuerreotypeScriptsDir/.constants.sh" \
@@ -47,7 +47,7 @@ echo
 echo "-- BUILDING TARBALLS FOR '$dpkgArch' FROM '$mirror/' --"
 echo
 
-thisDir="$(readlink -f "$BASH_SOURCE")"
+thisDir="$(readlink -vf "$BASH_SOURCE")"
 thisDir="$(dirname "$thisDir")"
 
 debianArgs=( --codename-copy )

--- a/examples/debian.sh
+++ b/examples/debian.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 debuerreotypeScriptsDir="$(which debuerreotype-init)"
-debuerreotypeScriptsDir="$(readlink -f "$debuerreotypeScriptsDir")"
+debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
 debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
 
 source "$debuerreotypeScriptsDir/.constants.sh" \
@@ -49,7 +49,7 @@ timestamp="${1:-}"; shift || eusage 'missing timestamp'
 
 set -x
 
-outputDir="$(readlink -e "$outputDir")"
+outputDir="$(readlink -ve "$outputDir")"
 
 tmpDir="$(mktemp --directory --tmpdir "debuerreotype.$suite.XXXXXXXXXX")"
 trap "$(printf 'rm -rf %q' "$tmpDir")" EXIT

--- a/examples/raspbian.sh
+++ b/examples/raspbian.sh
@@ -7,7 +7,7 @@ set -Eeuo pipefail
 # 	&& rm raspbian.deb
 
 debuerreotypeScriptsDir="$(which debuerreotype-init)"
-debuerreotypeScriptsDir="$(readlink -f "$debuerreotypeScriptsDir")"
+debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
 debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
 
 source "$debuerreotypeScriptsDir/.constants.sh" \
@@ -33,7 +33,7 @@ suite="${1:-}"; shift || eusage 'missing suite'
 
 set -x
 
-outputDir="$(readlink -e "$outputDir")"
+outputDir="$(readlink -ve "$outputDir")"
 
 tmpDir="$(mktemp --directory --tmpdir "debuerreotype.$suite.XXXXXXXXXX")"
 trap "$(printf 'rm -rf %q' "$tmpDir")" EXIT

--- a/examples/steamos.sh
+++ b/examples/steamos.sh
@@ -7,7 +7,7 @@ set -Eeuo pipefail
 # 	&& rm valve.deb
 
 debuerreotypeScriptsDir="$(which debuerreotype-init)"
-debuerreotypeScriptsDir="$(readlink -f "$debuerreotypeScriptsDir")"
+debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
 debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
 
 source "$debuerreotypeScriptsDir/.constants.sh" \
@@ -36,7 +36,7 @@ suite="${1:-brewmaster}" # http://repo.steampowered.com/steamos/dists/
 
 set -x
 
-outputDir="$(readlink -e "$outputDir")"
+outputDir="$(readlink -ve "$outputDir")"
 
 tmpDir="$(mktemp --directory --tmpdir "debuerreotype.$suite.XXXXXXXXXX")"
 trap "$(printf 'rm -rf %q' "$tmpDir")" EXIT

--- a/examples/ubuntu.sh
+++ b/examples/ubuntu.sh
@@ -6,7 +6,7 @@ set -Eeuo pipefail
 # 	&& rm -rf /var/lib/apt/lists/*
 
 debuerreotypeScriptsDir="$(which debuerreotype-init)"
-debuerreotypeScriptsDir="$(readlink -f "$debuerreotypeScriptsDir")"
+debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
 debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
 
 source "$debuerreotypeScriptsDir/.constants.sh" \
@@ -36,7 +36,7 @@ suite="${1:-}"; shift || eusage 'missing suite'
 
 set -x
 
-outputDir="$(readlink -e "$outputDir")"
+outputDir="$(readlink -ve "$outputDir")"
 
 tmpDir="$(mktemp --directory --tmpdir "debuerreotype.$suite.XXXXXXXXXX")"
 trap "$(printf 'rm -rf %q' "$tmpDir")" EXIT

--- a/scripts/.apt-version.sh
+++ b/scripts/.apt-version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	'<target-dir>' \
 	'rootfs'

--- a/scripts/.constants.sh
+++ b/scripts/.constants.sh
@@ -3,7 +3,7 @@
 # constants of the universe
 export TZ='UTC' LC_ALL='C'
 umask 0002
-scriptsDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+scriptsDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 self="$(basename "$0")"
 
 options="$(getopt -n "$BASH_SOURCE" -o '+' --long 'flags:,flags-short:' -- "$@")"

--- a/scripts/.debian-mirror.sh
+++ b/scripts/.debian-mirror.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	--flags 'eol,ports' \
 	-- \

--- a/scripts/.dpkg-arch.sh
+++ b/scripts/.dpkg-arch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	'<target-dir>' \
 	'rootfs'

--- a/scripts/.fix-apt-comments.sh
+++ b/scripts/.fix-apt-comments.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	'<apt-version> <file> [file ...]' \
 	'0.7.22 rootfs/etc/apt/apt.conf.d/example'

--- a/scripts/.snapshot-url.sh
+++ b/scripts/.snapshot-url.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	'<timestamp> [archive]' \
 	'2017-05-08T00:00:00Z debian-security'

--- a/scripts/debuerreotype-apt-get
+++ b/scripts/debuerreotype-apt-get
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	'<target-dir> arguments' \
 	'rootfs update'

--- a/scripts/debuerreotype-chroot
+++ b/scripts/debuerreotype-chroot
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	'<target-dir> <command> [args...]' \
 	'rootfs apt-get update'

--- a/scripts/debuerreotype-debian-sources-list
+++ b/scripts/debuerreotype-debian-sources-list
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	--flags 'eol,ports,snapshot' \
 	--flags 'deb-src' \

--- a/scripts/debuerreotype-fixup
+++ b/scripts/debuerreotype-fixup
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	'<target-dir>' \
 	'rootfs'

--- a/scripts/debuerreotype-gpgv-ignore-expiration-config
+++ b/scripts/debuerreotype-gpgv-ignore-expiration-config
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	'<target-dir>' \
 	'rootfs'

--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	--flags 'debian,debian-eol,debian-ports,non-debian' \
 	--flags 'debootstrap:' \
@@ -108,10 +108,10 @@ fi
 minbaseSupported="$(
 	scriptFile="$(
 		if [ -n "$script" ]; then
-			readlink -f "$script"
+			readlink -vf "$script"
 		else
 			cd /usr/share/debootstrap/scripts
-			readlink -f "$suite"
+			readlink -vf "$suite"
 		fi
 	)"
 	if grep -q 'minbase' "$scriptFile"; then

--- a/scripts/debuerreotype-minimizing-config
+++ b/scripts/debuerreotype-minimizing-config
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	'<target-dir>' \
 	'rootfs'

--- a/scripts/debuerreotype-slimify
+++ b/scripts/debuerreotype-slimify
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	'<target-dir>' \
 	'rootfs'

--- a/scripts/debuerreotype-tar
+++ b/scripts/debuerreotype-tar
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	--flags 'exclude:' \
 	--flags 'include-dev' \

--- a/scripts/debuerreotype-version
+++ b/scripts/debuerreotype-version
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-thisDir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	'' \
 	''


### PR DESCRIPTION
If any of these ever fails, they won't print an error without `-v` (and many of them are used as sanity checks, so this is both useful and important).