### PR TITLE
Add new "debuerreotype-recalculate-epoch" script for non-Debian chroots

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Available scripts:
 | `debuerreotype-minimizing-config` | apply configuration tweaks to make the rootfs minimal and keep it minimal (especially targeted at Docker images, with comments explicitly describing Docker use cases) |
 | `debuerreotype-slimify` | remove files such as documentation to create an even smaller rootfs (used for creating `slim` variants of the Docker images, for example) |
 | `debuerreotype-debian-sources-list` | generate an appropriate Debian `sources.list` in the rootfs given a suite (especially for updating `sources.list` to point at deb.debian.org before generating outputs) |
+| `debuerreotype-recalculate-epoch` | (esp. for non-Debian) recalculate `debuerreotype-epoch` from `/var/lib/apt/lists/*_{In,}Release` files' `Date:` fields (after updating `sources.list` / `apt-get update`) |
 | `debuerreotype-fixup` | invoked by `debuerreotype-tar` to fixup timestamps and remove known-bad log files for determinism |
 | `debuerreotype-tar` | deterministically create a tar file of the rootfs |
 | `debuerreotype-version` | print out the version of the current `debuerreotype` installation |

--- a/examples/raspbian.sh
+++ b/examples/raspbian.sh
@@ -101,6 +101,12 @@ initArgs=(
 rootfsDir="$tmpDir/rootfs"
 debuerreotype-init "${initArgs[@]}" "$rootfsDir" "$suite" "$mirror"
 
+debuerreotype-minimizing-config "$rootfsDir"
+
+# TODO do we need to update sources.list here? (security?)
+debuerreotype-apt-get "$rootfsDir" update -qq
+
+debuerreotype-recalculate-epoch "$rootfsDir"
 epoch="$(< "$rootfsDir/debuerreotype-epoch")"
 touch_epoch() {
 	while [ "$#" -gt 0 ]; do
@@ -109,8 +115,6 @@ touch_epoch() {
 	done
 }
 
-debuerreotype-minimizing-config "$rootfsDir"
-debuerreotype-apt-get "$rootfsDir" update -qq
 debuerreotype-apt-get "$rootfsDir" dist-upgrade -yqq
 
 # make a couple copies of rootfs so we can create other variants

--- a/examples/steamos.sh
+++ b/examples/steamos.sh
@@ -95,6 +95,12 @@ initArgs+=(
 rootfsDir="$tmpDir/rootfs"
 debuerreotype-init "${initArgs[@]}" "$rootfsDir" "$suite" "$mirror"
 
+debuerreotype-minimizing-config "$rootfsDir"
+
+echo "deb $mirror $suite main contrib non-free" | tee "$rootfsDir/etc/apt/sources.list"
+debuerreotype-apt-get "$rootfsDir" update -qq
+
+debuerreotype-recalculate-epoch "$rootfsDir"
 epoch="$(< "$rootfsDir/debuerreotype-epoch")"
 touch_epoch() {
 	while [ "$#" -gt 0 ]; do
@@ -102,12 +108,8 @@ touch_epoch() {
 		touch --no-dereference --date="@$epoch" "$f"
 	done
 }
-
-echo "deb $mirror $suite main contrib non-free" | tee "$rootfsDir/etc/apt/sources.list"
 touch_epoch "$rootfsDir/etc/apt/sources.list"
 
-debuerreotype-minimizing-config "$rootfsDir"
-debuerreotype-apt-get "$rootfsDir" update -qq
 debuerreotype-apt-get "$rootfsDir" dist-upgrade -yqq
 
 # make a couple copies of rootfs so we can create other variants
@@ -120,7 +122,7 @@ fi
 
 # prefer iproute2 if it exists
 iproute=iproute2
-if ! debuerreotype-chroot rootfs apt-get install -qq -s iproute2 &> /dev/null; then
+if ! debuerreotype-apt-get "$rootfsDir" install -qq -s iproute2 &> /dev/null; then
 	# poor wheezy
 	iproute=iproute
 fi

--- a/examples/ubuntu.sh
+++ b/examples/ubuntu.sh
@@ -94,6 +94,19 @@ initArgs=(
 rootfsDir="$tmpDir/rootfs"
 debuerreotype-init "${initArgs[@]}" "$rootfsDir" "$suite" "$mirror"
 
+debuerreotype-minimizing-config "$rootfsDir"
+
+# setup "proper" sources.list
+tee "$rootfsDir/etc/apt/sources.list" <<-EOS
+	deb $mirror $suite main restricted universe multiverse
+	deb $mirror $suite-updates main restricted universe multiverse
+	deb $mirror $suite-backports main restricted universe multiverse
+	deb $secmirror $suite-security main restricted universe multiverse
+EOS
+# TODO make components list a script flag?  backports?
+debuerreotype-apt-get "$rootfsDir" update -qq
+
+debuerreotype-recalculate-epoch "$rootfsDir"
 epoch="$(< "$rootfsDir/debuerreotype-epoch")"
 touch_epoch() {
 	while [ "$#" -gt 0 ]; do
@@ -101,15 +114,8 @@ touch_epoch() {
 		touch --no-dereference --date="@$epoch" "$f"
 	done
 }
+touch_epoch "$rootfsDir/etc/apt/sources.list"
 
-# TODO setup proper sources.list for Ubuntu
-# deb http://archive.ubuntu.com/ubuntu xenial main restricted universe multiverse
-# deb http://archive.ubuntu.com/ubuntu xenial-updates main restricted universe multiverse
-# deb http://archive.ubuntu.com/ubuntu xenial-backports main restricted universe multiverse
-# deb http://security.ubuntu.com/ubuntu xenial-security main restricted universe multiverse
-
-debuerreotype-minimizing-config "$rootfsDir"
-debuerreotype-apt-get "$rootfsDir" update -qq
 debuerreotype-apt-get "$rootfsDir" dist-upgrade -yqq
 
 # make a couple copies of rootfs so we can create other variants

--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -75,7 +75,8 @@ else
 		} | awk -F ': ' '$1 == "Date" { print $2; exit }'
 	)" || :
 	[ -n "$timestamp" ]
-	# TODO re-calculate "timestamp" during debuerreotype-tar/fixup (possibly scraping from /var/lib/apt/lists/*Release* instead?)
+
+	# see "debuerreotype-recalculate-epoch" for a simple way to update this value appropriately after "sources.list" is updated and "apt-get update" has been run (which will be more accurate)
 fi
 
 epoch="$(date --date "$timestamp" '+%s')"

--- a/scripts/debuerreotype-recalculate-epoch
+++ b/scripts/debuerreotype-recalculate-epoch
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
+source "$thisDir/.constants.sh" \
+	'<target-dir>' \
+	'rootfs'
+
+eval "$dgetopt"
+while true; do
+	flag="$1"; shift
+	dgetopt-case "$flag"
+	case "$flag" in
+		--) break ;;
+		*) eusage "unknown flag '$flag'" ;;
+	esac
+done
+
+targetDir="${1:-}"; shift || eusage 'missing target-dir'
+[ -n "$targetDir" ]
+
+# ideally this would use something like "apt-get indextargets" instead of hard-coding these particular "/var/lib/apt/lists" paths, but it doesn't include the Release files :(
+# also a caution from DonKult: "the Release file might really be an InRelease file which failed signature checks"
+
+shopt -s nullglob
+releaseFiles=( "$targetDir"/var/lib/apt/lists/*_{In,}Release )
+if [ "${#releaseFiles[@]}" -eq 0 ]; then
+	echo >&2 "error: no 'Release' files found at /var/lib/apt/lists in '$targetDir'"
+	echo >&2 "  did you forget to populate 'sources.list' or run 'apt-get update' first?"
+	exit 1
+fi
+
+epoch="$(
+	awk -F ': ' '$1 == "Date" { printf "%s%c", $2, 0 }' "${releaseFiles[@]}" \
+		| xargs -r0n1 date '+%s' --date \
+		| sort -un \
+		| tail -1
+)"
+echo "$epoch" > "$targetDir/debuerreotype-epoch"


### PR DESCRIPTION
This allows (for example) `examples/ubuntu.sh` to finally populate `/etc/apt/sources.list` appropriately.