### PR TITLE
Invoke "debootstrap" inside "unshare --mount" by default

### DIFF
--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -135,7 +135,12 @@ debootstrapArgs+=(
 )
 [ -z "$script" ] || debootstrapArgs+=( "$script" )
 
-: "${debootstrap:=debootstrap}"
+unshare-debootstrap() {
+	# avoid bugs in packages that might leave things mounted ("/run/shm" is a common one that sometimes ends up dangling)
+	unshare --mount debootstrap "$@"
+}
+
+: "${debootstrap:=unshare-debootstrap}"
 if ! "$debootstrap" "${debootstrapArgs[@]}"; then
 	if [ -f "$targetDir/debootstrap/debootstrap.log" ]; then
 		echo >&2


### PR DESCRIPTION
This is similar to what happens in `debuerreotype-chroot`, but for `debootstrap` too, since sometimes the scripts for the initial packages can leave dangling mounts (most notably `/run/shm` in wheezy).