### PR TITLE
Remove sbuild variants

### DIFF
--- a/examples/debian-all.sh
+++ b/examples/debian-all.sh
@@ -17,9 +17,9 @@ debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
 debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
 
 source "$debuerreotypeScriptsDir/.constants.sh" \
-	--flags 'arch:,qemu,sbuild' \
+	--flags 'arch:,qemu' \
 	-- \
-	'[--arch=<arch>] [--qemu] [--sbuild] <output-dir> <timestamp>' \
+	'[--arch=<arch>] [--qemu] <output-dir> <timestamp>' \
 	'output 2017-05-08T00:00:00Z'
 
 eval "$dgetopt"
@@ -30,7 +30,7 @@ while true; do
 	dgetopt-case "$flag"
 	case "$flag" in
 		--arch) arch="$1"; shift ;;
-		--qemu | --sbuild) debianArgs+=( "$flag" ) ;;
+		--qemu) debianArgs+=( "$flag" ) ;;
 		--) break ;;
 		*) eusage "unknown flag '$flag'" ;;
 	esac

--- a/examples/oci-image.sh
+++ b/examples/oci-image.sh
@@ -72,7 +72,7 @@ if [ -s "$sourceDir/rootfs.debuerreotype-variant" ]; then
 else
 	dirBase="$(basename "$sourceDir")"
 	case "$dirBase" in
-		slim | sbuild) variant="$dirBase" ;;
+		slim) variant="$dirBase" ;;
 		"$suite") variant='' ;;
 		*) echo >&2 "error: unknown variant: '$variant'"; exit 1 ;;
 	esac

--- a/examples/steamos.sh
+++ b/examples/steamos.sh
@@ -12,20 +12,17 @@ debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
 
 source "$debuerreotypeScriptsDir/.constants.sh" \
 	--flags 'arch:' \
-	--flags 'sbuild' \
 	-- \
 	'[--arch=<arch>] <output-dir> <suite>' \
 	'output'
 
 eval "$dgetopt"
 arch=
-sbuild=
 while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
 	case "$flag" in
 		--arch) arch="$1"; shift ;; # for adding "--arch" to debuerreotype-init
-		--sbuild) sbuild=1 ;; # for building "sbuild" compatible tarballs as well
 		--) break ;;
 		*) eusage "unknown flag '$flag'" ;;
 	esac
@@ -112,13 +109,9 @@ touch_epoch "$rootfsDir/etc/apt/sources.list"
 
 debuerreotype-apt-get "$rootfsDir" dist-upgrade -yqq
 
-# make a couple copies of rootfs so we can create other variants
+# copy the rootfs to create other variants
 mkdir "$rootfsDir"-slim
 tar -cC "$rootfsDir" . | tar -xC "$rootfsDir"-slim
-if [ -n "$sbuild" ]; then
-	mkdir "$rootfsDir"-sbuild
-	tar -cC "$rootfsDir" . | tar -xC "$rootfsDir"-sbuild
-fi
 
 # prefer iproute2 if it exists
 iproute=iproute2
@@ -130,19 +123,6 @@ debuerreotype-apt-get "$rootfsDir" install -y --no-install-recommends iputils-pi
 
 debuerreotype-slimify "$rootfsDir"-slim
 
-if [ -n "$sbuild" ]; then
-	fakeroot=fakeroot
-	if [[ "$suite" == alchemist* ]]; then
-		# poor alchemist
-		fakeroot=
-	fi
-
-	# this should match the list added to the "buildd" variant in debootstrap and the list installed by sbuild
-	# https://salsa.debian.org/installer-team/debootstrap/blob/da5f17904de373cd7a9224ad7cd69c80b3e7e234/scripts/debian-common#L20
-	# https://salsa.debian.org/debian/sbuild/blob/fc306f4be0d2c57702c5e234273cd94b1dba094d/bin/sbuild-createchroot#L257-260
-	debuerreotype-apt-get "$rootfsDir"-sbuild install -y --no-install-recommends build-essential $fakeroot
-fi
-
 create_artifacts() {
 	local targetBase="$1"; shift
 	local rootfs="$1"; shift
@@ -150,23 +130,6 @@ create_artifacts() {
 	local variant="$1"; shift
 
 	local tarArgs=()
-
-	if [ "$variant" = 'sbuild' ]; then
-		# sbuild needs "deb-src" entries
-		debuerreotype-chroot "$rootfs" sed -ri -e '/^deb / p; s//deb-src /' /etc/apt/sources.list
-
-		# APT has odd issues with "Acquire::GzipIndexes=false" + "file://..." sources sometimes
-		# (which are used in sbuild for "--extra-package")
-		#   Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
-		#   ...
-		#   E: Failed to fetch store:/var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages  Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
-		rm -f "$rootfs/etc/apt/apt.conf.d/docker-gzip-indexes"
-		# TODO figure out the bug and fix it in APT instead /o\
-
-		# schroot is picky about "/dev" (which is excluded by default in "debuerreotype-tar")
-		# see https://github.com/debuerreotype/debuerreotype/pull/8#issuecomment-305855521
-		tarArgs+=( --include-dev )
-	fi
 
 	debuerreotype-tar "${tarArgs[@]}" "$rootfs" "$targetBase.tar.xz"
 	du -hsx "$targetBase.tar.xz"

--- a/examples/ubuntu.sh
+++ b/examples/ubuntu.sh
@@ -11,7 +11,6 @@ debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
 
 source "$debuerreotypeScriptsDir/.constants.sh" \
 	--flags 'arch:' \
-	--flags 'sbuild' \
 	-- \
 	'[--arch=<arch>] <output-dir> <suite>' \
 	'output xenial
@@ -19,13 +18,11 @@ source "$debuerreotypeScriptsDir/.constants.sh" \
 
 eval "$dgetopt"
 arch=
-sbuild=
 while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
 	case "$flag" in
 		--arch) arch="$1"; shift ;; # for adding "--arch" to debuerreotype-init
-		--sbuild) sbuild=1 ;; # for building "sbuild" compatible tarballs as well
 		--) break ;;
 		*) eusage "unknown flag '$flag'" ;;
 	esac
@@ -118,24 +115,13 @@ touch_epoch "$rootfsDir/etc/apt/sources.list"
 
 debuerreotype-apt-get "$rootfsDir" dist-upgrade -yqq
 
-# make a couple copies of rootfs so we can create other variants
+# copy the rootfs to create other variants
 mkdir "$rootfsDir"-slim
 tar -cC "$rootfsDir" . | tar -xC "$rootfsDir"-slim
-if [ -n "$sbuild" ]; then
-	mkdir "$rootfsDir"-sbuild
-	tar -cC "$rootfsDir" . | tar -xC "$rootfsDir"-sbuild
-fi
 
 debuerreotype-apt-get "$rootfsDir" install -y --no-install-recommends iproute2 iputils-ping
 
 debuerreotype-slimify "$rootfsDir"-slim
-
-if [ -n "$sbuild" ]; then
-	# this should match the list added to the "buildd" variant in debootstrap and the list installed by sbuild
-	# https://salsa.debian.org/installer-team/debootstrap/blob/da5f17904de373cd7a9224ad7cd69c80b3e7e234/scripts/debian-common#L20
-	# https://salsa.debian.org/debian/sbuild/blob/fc306f4be0d2c57702c5e234273cd94b1dba094d/bin/sbuild-createchroot#L257-260
-	debuerreotype-apt-get "$rootfsDir"-sbuild install -y --no-install-recommends build-essential fakeroot
-fi
 
 create_artifacts() {
 	local targetBase="$1"; shift
@@ -144,23 +130,6 @@ create_artifacts() {
 	local variant="$1"; shift
 
 	local tarArgs=()
-
-	if [ "$variant" = 'sbuild' ]; then
-		# sbuild needs "deb-src" entries
-		debuerreotype-chroot "$rootfs" sed -ri -e '/^deb / p; s//deb-src /' /etc/apt/sources.list
-
-		# APT has odd issues with "Acquire::GzipIndexes=false" + "file://..." sources sometimes
-		# (which are used in sbuild for "--extra-package")
-		#   Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
-		#   ...
-		#   E: Failed to fetch store:/var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages  Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
-		rm -f "$rootfs/etc/apt/apt.conf.d/docker-gzip-indexes"
-		# TODO figure out the bug and fix it in APT instead /o\
-
-		# schroot is picky about "/dev" (which is excluded by default in "debuerreotype-tar")
-		# see https://github.com/debuerreotype/debuerreotype/pull/8#issuecomment-305855521
-		tarArgs+=( --include-dev )
-	fi
 
 	debuerreotype-tar "${tarArgs[@]}" "$rootfs" "$targetBase.tar.xz"
 	du -hsx "$targetBase.tar.xz"


### PR DESCRIPTION
There are other reasonable ways to create these that don't involve using such low level tooling (https://github.com/tianon/debian-bin/blob/7d6951fa33b8cf104f91f08afa3767343cfb4476/docker-sbuild/docker-image-to-sbuild-schroot), and thus have a lot more flexibility.

Closes #115
Refs #68