### PR TITLE
Add a test to validate no-https snapshot usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           - { DISTRO: ubuntu, SUITE: bionic }
           - { DISTRO: ubuntu, SUITE: focal }
       fail-fast: false
+    name: Test ${{ matrix.DISTRO && format('{0} ', matrix.DISTRO) }}${{ matrix.SUITE }}${{ matrix.CODENAME && format(' ({0})', matrix.CODENAME) }}${{ matrix.ARCH && format(' [{0}]', matrix.ARCH) }}${{ matrix.TIMESTAMP && format(' at {0}', matrix.TIMESTAMP) }}
     runs-on: ubuntu-20.04
     env: ${{ matrix }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ defaults:
 
 jobs:
 
+  https:
+    name: Ensure no-TLS snapshot usage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Ensure http://snapshot.debian.org (https://github.com/debuerreotype/debuerreotype/pull/119#issuecomment-901457009)
+        run: |
+          rm .github/workflows/ci.yml # this file itself will always be a match, but it's the only valid one 👀
+          ! grep -rn 'https://snapshot.debian.org'
+
   test:
     strategy:
       matrix:

--- a/.validate-ubuntu.sh
+++ b/.validate-ubuntu.sh
@@ -7,8 +7,8 @@ dockerImage+='-ubuntu'
 	cat Dockerfile - <<-'EODF'
 		RUN set -eux; \
 # https://bugs.debian.org/929165 :(
-# https://snapshot.debian.org/package/ubuntu-keyring/
-# https://snapshot.debian.org/package/ubuntu-keyring/2020.06.17.1-1/
+# http://snapshot.debian.org/package/ubuntu-keyring/
+# http://snapshot.debian.org/package/ubuntu-keyring/2020.06.17.1-1/
 			wget -O ubuntu-keyring.deb 'http://snapshot.debian.org/archive/debian/20210307T083530Z/pool/main/u/ubuntu-keyring/ubuntu-keyring_2020.06.17.1-1_all.deb'; \
 			echo 'c2d8c4a9be6244bbea80c2e0e7624cbd3a2006a2 *ubuntu-keyring.deb' | sha1sum --strict --check -; \
 			apt-get install -y --no-install-recommends ./ubuntu-keyring.deb; \


### PR DESCRIPTION
This should help avoid "oops" moments like a4582efca5301591bb59f9766ca15a98a0582090 (which happens repeatedly).

Closes #119