### PR TITLE
Add Slink support (and various other minor tweaks)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,16 @@ RUN set -eux; \
 	rm distro-info-data.deb; \
 	[ -s /usr/share/distro-info/debian.csv ]
 
+# https://salsa.debian.org/installer-team/debootstrap/-/merge_requests/63
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends patch; \
+	rm -rf /var/lib/apt/lists/*; \
+	wget -O debootstrap-download-main.patch 'https://salsa.debian.org/installer-team/debootstrap/-/merge_requests/63.diff'; \
+	awk '$1 == "diff" { p = ($3 == "a/functions") } p { print }' debootstrap-download-main.patch > functions.patch; \
+	patch --input=functions.patch /usr/share/debootstrap/functions; \
+	rm debootstrap-download-main.patch functions.patch
+
 # see ".dockerignore"
 COPY . /opt/debuerreotype
 RUN set -eux; \

--- a/scripts/.apt-version.sh
+++ b/scripts/.apt-version.sh
@@ -19,12 +19,26 @@ done
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
 [ -n "$targetDir" ]
 
-# scrape our APT version so we can do some basic feature detection (especially to remove unsupported settings on --debian-eol)
+package="${1:-apt}"
+
+# if dpkg-query does not exist, we must be on woody or older, so just assume something ancient (suggested version is the one in woody, since it should be old enough for any "fancy" features we're using this to exclude)
+fallback=
+case "$package" in
+	apt) fallback='0.5.4' ;; # woody
+	dpkg) fallback='1.9.21' ;; # woody
+esac
+
+# scrape package versions so we can do some basic feature detection (especially to remove unsupported settings on --debian-eol)
 "$thisDir/debuerreotype-chroot" "$targetDir" bash -c '
+	package="$1"; shift
+	fallback="$1"; shift
 	if command -v dpkg-query &> /dev/null; then
-		dpkg-query --show --showformat "\${Version}\n" apt
+		dpkg-query --show --showformat "\${Version}\n" "$package"
+	elif [ -n "$fallback" ]; then
+		# if dpkg-query does not exist, we must be on woody or older
+		echo "$fallback"
 	else
-		# if dpkg-query does not exist, we must be on woody or potato, so just assume something ancient like 0.5.4 (since that is what woody includes and is old enough to cover all our features being excluded)
-		echo 0.5.4
+		echo >&2 "error: missing dpkg-query and no fallback defined in debuerreotype for $package"
+		exit 1
 	fi
-'
+' -- "$package" "$fallback"

--- a/scripts/.debootstrap-scripts/potato
+++ b/scripts/.debootstrap-scripts/potato
@@ -1,0 +1,106 @@
+mirror_style release
+download_style apt var-state
+default_mirror http://archive.debian.org/debian
+keyring /usr/share/keyrings/debian-archive-removed-keys.gpg
+force_md5
+
+LIBC=libc6
+if [ "$ARCH" = alpha ]; then
+  LIBC="libc6.1"
+fi
+
+work_out_debs () {
+    required="base-files base-passwd bash bsdutils debconf-tiny debianutils diff dpkg e2fsprogs fileutils findutils grep gzip hostname ldso libc6 libdb2 libgdbmg1 libncurses5 libnewt0 libpam-modules libpam-runtime libpam0g libpopt0 libreadline4 libstdc++2.10 login makedev mawk modutils mount ncurses-base ncurses-bin passwd perl-5.005-base perl-base procps sed shellutils slang1 sysklogd sysvinit tar textutils update util-linux whiptail"
+
+    base="adduser ae apt base-config elvis-tiny fbset fdutils gettext-base console-data console-tools console-tools-libs libdb2 libwrap0 locales modconf netbase ftp ppp pppconfig pump tasksel tcpd textutils telnet xviddetect"
+
+    without_package () {
+        echo "$2" | tr ' ' '\n' | grep -v "^$1$" | tr '\n' ' '
+    }
+
+    case $ARCH in
+      "alpha")
+        required="$(without_package "libc6" "$required") libc6.1"
+        ;;
+      "i386")
+        base="$base fdflush isapnptools lilo mbr pciutils pcmcia-cs psmisc setserial syslinux"
+        ;;
+       *)
+        # other arches may have special needs not yet represented here
+        # oh well, Potato is old
+    esac
+}
+
+first_stage_install () {
+    extract $required
+
+    :> "$TARGET/var/lib/dpkg/status"
+    echo > "$TARGET/var/lib/dpkg/available"
+
+    setup_etc
+    echo '# UNCONFIGURED FSTAB FOR BASE SYSTEM' > "$TARGET/etc/fstab"
+    chown 0:0 "$TARGET/etc/fstab"; chmod 644 "$TARGET/etc/fstab"
+
+    x_feign_install () {
+        local pkg=$1
+        local deb="$(debfor $pkg)"
+        local ver="$(extract_deb_field "$TARGET/$deb" Version)"
+
+        mkdir -p "$TARGET/var/lib/dpkg/info"
+
+echo \
+"Package: $pkg
+Version: $ver
+Status: install ok installed" >> "$TARGET/var/lib/dpkg/status"
+
+        touch "$TARGET/var/lib/dpkg/info/${pkg}.list"
+    }
+
+    setup_devices
+
+    x_feign_install dpkg
+
+    if [ -e "$TARGET/usr/bin/perl-5.005.dist" ]; then
+        mv "$TARGET/usr/bin/perl-5.005.dist" "$TARGET/usr/bin/perl-5.005"
+    fi
+    if [ ! -e "$TARGET/usr/bin/perl" ]; then
+        ln -sf perl-5.005 "$TARGET/usr/bin/perl"
+    fi
+}
+
+second_stage_install () {
+    x_core_install () {
+        in_target dpkg --force-depends --install $(debfor "$@")
+    }
+
+    export DEBIAN_FRONTEND=Noninteractive
+
+    setup_proc
+    ln "$TARGET/sbin/ldconfig.new" "$TARGET/sbin/ldconfig"
+    in_target /sbin/ldconfig
+
+    x_core_install base-files base-passwd ldso
+    x_core_install dpkg
+
+    ln -sf /usr/share/zoneinfo/UTC "$TARGET/etc/localtime"
+    x_core_install $LIBC
+
+    smallyes '' | x_core_install perl-5.005-base
+    x_core_install mawk
+    x_core_install debconf-tiny
+
+    in_target dpkg-preconfigure $(debfor $required $base)
+
+    repeatn 5 in_target dpkg --force-depends --unpack $(debfor $required)
+
+    mv "$TARGET/sbin/start-stop-daemon" "$TARGET/sbin/start-stop-daemon.REAL"
+    cp "$TARGET/bin/true" "$TARGET/sbin/start-stop-daemon"
+
+    setup_dselect_method apt
+
+    in_target dpkg --configure --pending --force-configure-any --force-depends
+
+    smallyes '' | repeatn 5 in_target dpkg --force-auto-select --force-overwrite --skip-same-version --install $(debfor $base)
+
+    mv "$TARGET/sbin/start-stop-daemon.REAL" "$TARGET/sbin/start-stop-daemon"
+}

--- a/scripts/.debootstrap-scripts/potato
+++ b/scripts/.debootstrap-scripts/potato
@@ -1,7 +1,6 @@
 mirror_style release
 download_style apt var-state
 default_mirror http://archive.debian.org/debian
-keyring /usr/share/keyrings/debian-archive-removed-keys.gpg
 force_md5
 
 LIBC=libc6

--- a/scripts/.debootstrap-scripts/potato
+++ b/scripts/.debootstrap-scripts/potato
@@ -82,7 +82,19 @@ second_stage_install () {
     x_core_install dpkg
 
     ln -sf /usr/share/zoneinfo/UTC "$TARGET/etc/localtime"
-    x_core_install $LIBC
+
+    # the libc6 and sysvinit postinst scripts want to run "init u" to re-exec sysvinit, but that sends SIGHUP to PID 1, which is undesirable (for hopefully obvious reasons), so we have to get a little bit clever while installing libc6 and later before configuring the rest of the system
+    x_hack_avoid_postinst_init() {
+        local postinst
+        for postinst in "$TARGET"/var/lib/dpkg/info/*.postinst; do
+            if grep -qE '^[[:space:]]*init[[:space:]]' "$postinst" 2>/dev/null; then
+                sed -ri -e 's/^([[:space:]]*)(init[[:space:]])/\1: # \2/' "$postinst"
+            fi
+        done
+    }
+    in_target dpkg --force-depends --unpack $(debfor $LIBC)
+    x_hack_avoid_postinst_init
+    in_target dpkg --force-depends --configure $LIBC
 
     smallyes '' | x_core_install perl-5.005-base
     x_core_install mawk
@@ -91,6 +103,9 @@ second_stage_install () {
     in_target dpkg-preconfigure $(debfor $required $base)
 
     repeatn 5 in_target dpkg --force-depends --unpack $(debfor $required)
+
+    # see above
+    x_hack_avoid_postinst_init
 
     mv "$TARGET/sbin/start-stop-daemon" "$TARGET/sbin/start-stop-daemon.REAL"
     cp "$TARGET/bin/true" "$TARGET/sbin/start-stop-daemon"

--- a/scripts/.debootstrap-scripts/potato
+++ b/scripts/.debootstrap-scripts/potato
@@ -1,3 +1,7 @@
+#
+# This script was taken from debootstrap version 1.0.125 and then hacked to avoid invoking "init u" in postinst scripts (which tries to send SIGHUP to PID 1).
+#
+
 mirror_style release
 download_style apt var-state
 default_mirror http://archive.debian.org/debian

--- a/scripts/.debootstrap-scripts/slink
+++ b/scripts/.debootstrap-scripts/slink
@@ -1,0 +1,88 @@
+
+mirror_style main
+download_style apt var-state
+
+work_out_debs () {
+    required="base-files base-passwd bash bsdutils debianutils diff dpkg e2fsprogs fileutils findutils grep gzip hostname ldso libdb2 libgdbmg1 libncurses4 ncurses3.4 libpam0g libpam0g-util libpwdb0g libreadlineg2 libstdc++2.9 login makedev mawk modutils mount ncurses-base ncurses-bin newt0.25 passwd perl-base procps sed shellutils slang1 sysklogd sysvinit tar textutils update util-linux whiptail"
+
+    base="adduser ae apt elvis-tiny fbset fdutils console-tools console-tools-libs libdb2 locales modconf netbase ppp pppconfig textutils telnet"
+
+    case $ARCH in
+        "i386")
+            required="$required libc6"
+            base="$base fdflush isapnptools lilo mbr pciutils psmisc setserial syslinux"
+            ;;
+    esac
+
+    all_debs="$required $base"
+}
+
+install_debs () {
+    extract $required
+
+    :> "$TARGET/var/lib/dpkg/status"
+    :> "$TARGET/var/lib/dpkg/available"
+
+    setup_etc
+    echo '# UNCONFIGURED FSTAB FOR BASE SYSTEM' > "$TARGET/etc/fstab"
+    chown 0.0 $TARGET/etc/fstab; chmod 644 $TARGET/etc/fstab
+
+    mkdir -p "$TARGET/dev/pts"
+
+    setup_proc
+    setup_devices
+
+    mv "$TARGET/usr/bin/perl.dist" "$TARGET/usr/bin/perl"
+
+    ln "$TARGET/sbin/ldconfig.new" "$TARGET/sbin/ldconfig"
+    in_target /sbin/ldconfig
+
+    x_feign_install () {
+        local pkg=$1
+        local deb="$(debfor $pkg)"
+        local ver="$(
+            ar -p $TARGET/$deb control.tar.gz | zcat |
+                tar -O -xf - control ./control 2>/dev/null |
+                sed -ne 's/^Version: *//Ip' | head -n 1
+        )"
+
+        mkdir -p "$TARGET/var/lib/dpkg/info"
+    
+echo \
+"Package: $pkg
+Version: $ver
+Status: install ok installed" >> "$TARGET/var/lib/dpkg/status"
+
+        touch "$TARGET/var/lib/dpkg/info/${pkg}.list"
+    }
+
+    x_core_install () {
+        in_target dpkg --force-depends --install $(debfor "$@")
+    }
+
+    x_feign_install dpkg
+
+    x_core_install base-files base-passwd ldso
+    x_core_install dpkg
+
+    ln -sf /usr/share/zoneinfo/UTC "$TARGET/etc/localtime"
+    x_core_install libc6
+
+    x_core_install perl-base
+    x_core_install mawk
+
+    repeat 5 in_target dpkg --force-depends --unpack $(debfor $required)
+
+    mv "$TARGET/sbin/start-stop-daemon" "$TARGET/sbin/start-stop-daemon.REAL"
+    cp "$TARGET/bin/true" "$TARGET/sbin/start-stop-daemon"
+
+    setup_dselect_method apt
+    #on_exit "in_target umount /dev/pts"
+
+    in_target dpkg --configure --pending --force-configure-any --force-depends
+
+    smallyes '' | repeat 5 in_target dpkg --force-auto-select --force-overwrite \
+        --skip-same-version --install $(debfor $base)
+
+    mv "$TARGET/sbin/start-stop-daemon.REAL" "$TARGET/sbin/start-stop-daemon"
+}

--- a/scripts/.debootstrap-scripts/slink
+++ b/scripts/.debootstrap-scripts/slink
@@ -6,7 +6,7 @@ force_md5
 work_out_debs () {
     required="base-files base-passwd bash bsdutils debianutils diff dpkg e2fsprogs fileutils findutils grep gzip hostname ldso libdb2 libgdbmg1 libncurses4 ncurses3.4 libpam0g libpam0g-util libpwdb0g libreadlineg2 libstdc++2.9 login makedev mawk modutils mount ncurses-base ncurses-bin newt0.25 passwd perl-base procps sed shellutils slang1 sysklogd sysvinit tar textutils update util-linux whiptail"
 
-    base="adduser ae apt elvis-tiny fbset fdutils console-tools console-tools-libs libdb2 locales modconf netbase ppp pppconfig textutils telnet"
+    base="adduser ae apt elvis-tiny fbset fdutils console-tools console-tools-libs libdb2 locales modconf netbase textutils telnet"
 
     case $ARCH in
         "i386")

--- a/scripts/.debootstrap-scripts/slink
+++ b/scripts/.debootstrap-scripts/slink
@@ -61,12 +61,27 @@ second_stage_install () {
     x_core_install dpkg
 
     ln -sf /usr/share/zoneinfo/UTC "$TARGET/etc/localtime"
-    x_core_install libc6
+
+    # the libc6 and sysvinit postinst scripts want to run "init u" to re-exec sysvinit, but that sends SIGHUP to PID 1, which is undesirable (for hopefully obvious reasons), so we have to get a little bit clever while installing libc6 and later before configuring the rest of the system
+    x_hack_avoid_postinst_init() {
+        local postinst
+        for postinst in "$TARGET"/var/lib/dpkg/info/*.postinst; do
+            if grep -qE '^[[:space:]]*init[[:space:]]' "$postinst" 2>/dev/null; then
+                sed -ri -e 's/^([[:space:]]*)(init[[:space:]])/\1: # \2/' "$postinst"
+            fi
+        done
+    }
+    in_target dpkg --force-depends --unpack $(debfor libc6)
+    x_hack_avoid_postinst_init
+    in_target dpkg --force-depends --configure libc6
 
     x_core_install perl-base
     x_core_install mawk
 
     repeatn 5 in_target dpkg --force-depends --unpack $(debfor $required)
+
+    # see above
+    x_hack_avoid_postinst_init
 
     mv "$TARGET/sbin/start-stop-daemon" "$TARGET/sbin/start-stop-daemon.REAL"
     cp "$TARGET/bin/true" "$TARGET/sbin/start-stop-daemon"

--- a/scripts/.debootstrap-scripts/slink
+++ b/scripts/.debootstrap-scripts/slink
@@ -1,6 +1,7 @@
-
 mirror_style main
 download_style apt var-state
+default_mirror http://archive.debian.org/debian
+force_md5
 
 work_out_debs () {
     required="base-files base-passwd bash bsdutils debianutils diff dpkg e2fsprogs fileutils findutils grep gzip hostname ldso libdb2 libgdbmg1 libncurses4 ncurses3.4 libpam0g libpam0g-util libpwdb0g libreadlineg2 libstdc++2.9 login makedev mawk modutils mount ncurses-base ncurses-bin newt0.25 passwd perl-base procps sed shellutils slang1 sysklogd sysvinit tar textutils update util-linux whiptail"
@@ -13,41 +14,25 @@ work_out_debs () {
             base="$base fdflush isapnptools lilo mbr pciutils psmisc setserial syslinux"
             ;;
     esac
-
-    all_debs="$required $base"
 }
 
-install_debs () {
+first_stage_install () {
     extract $required
 
     :> "$TARGET/var/lib/dpkg/status"
-    :> "$TARGET/var/lib/dpkg/available"
+    echo > "$TARGET/var/lib/dpkg/available"
 
     setup_etc
     echo '# UNCONFIGURED FSTAB FOR BASE SYSTEM' > "$TARGET/etc/fstab"
-    chown 0.0 $TARGET/etc/fstab; chmod 644 $TARGET/etc/fstab
-
-    mkdir -p "$TARGET/dev/pts"
-
-    setup_proc
-    setup_devices
-
-    mv "$TARGET/usr/bin/perl.dist" "$TARGET/usr/bin/perl"
-
-    ln "$TARGET/sbin/ldconfig.new" "$TARGET/sbin/ldconfig"
-    in_target /sbin/ldconfig
+    chown 0:0 "$TARGET/etc/fstab"; chmod 644 "$TARGET/etc/fstab"
 
     x_feign_install () {
         local pkg=$1
         local deb="$(debfor $pkg)"
-        local ver="$(
-            ar -p $TARGET/$deb control.tar.gz | zcat |
-                tar -O -xf - control ./control 2>/dev/null |
-                sed -ne 's/^Version: *//Ip' | head -n 1
-        )"
+        local ver="$(extract_deb_field "$TARGET/$deb" Version)"
 
         mkdir -p "$TARGET/var/lib/dpkg/info"
-    
+
 echo \
 "Package: $pkg
 Version: $ver
@@ -56,11 +41,21 @@ Status: install ok installed" >> "$TARGET/var/lib/dpkg/status"
         touch "$TARGET/var/lib/dpkg/info/${pkg}.list"
     }
 
+    setup_devices
+
+    x_feign_install dpkg
+
+    mv "$TARGET/usr/bin/perl.dist" "$TARGET/usr/bin/perl"
+}
+
+second_stage_install () {
     x_core_install () {
         in_target dpkg --force-depends --install $(debfor "$@")
     }
 
-    x_feign_install dpkg
+    setup_proc
+    ln "$TARGET/sbin/ldconfig.new" "$TARGET/sbin/ldconfig"
+    in_target /sbin/ldconfig
 
     x_core_install base-files base-passwd ldso
     x_core_install dpkg
@@ -71,17 +66,16 @@ Status: install ok installed" >> "$TARGET/var/lib/dpkg/status"
     x_core_install perl-base
     x_core_install mawk
 
-    repeat 5 in_target dpkg --force-depends --unpack $(debfor $required)
+    repeatn 5 in_target dpkg --force-depends --unpack $(debfor $required)
 
     mv "$TARGET/sbin/start-stop-daemon" "$TARGET/sbin/start-stop-daemon.REAL"
     cp "$TARGET/bin/true" "$TARGET/sbin/start-stop-daemon"
 
     setup_dselect_method apt
-    #on_exit "in_target umount /dev/pts"
 
     in_target dpkg --configure --pending --force-configure-any --force-depends
 
-    smallyes '' | repeat 5 in_target dpkg --force-auto-select --force-overwrite \
+    smallyes '' | repeatn 5 in_target dpkg --force-auto-select --force-overwrite \
         --skip-same-version --install $(debfor $base)
 
     mv "$TARGET/sbin/start-stop-daemon.REAL" "$TARGET/sbin/start-stop-daemon"

--- a/scripts/.debootstrap-scripts/slink
+++ b/scripts/.debootstrap-scripts/slink
@@ -1,3 +1,7 @@
+#
+# This script was taken from debootstrap version 0.2.45-0.2, adapted with several changes to match the corresponding changes to "potato" since it was removed, and then hacked to avoid invoking "init u" in postinst scripts (which tries to send SIGHUP to PID 1).
+#
+
 mirror_style main
 download_style apt var-state
 default_mirror http://archive.debian.org/debian

--- a/scripts/.dpkg-arch.sh
+++ b/scripts/.dpkg-arch.sh
@@ -19,6 +19,15 @@ done
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
 [ -n "$targetDir" ]
 
+if [ -s "$targetDir/etc/debian_version" ] && debVer="$(< "$targetDir/etc/debian_version")" && [ "$debVer" = '2.1' ]; then
+	# must be slink, where invoking "dpkg --print-architecture" leads to:
+	#   dpkg (subprocess): failed to exec C compiler `gcc': No such file or directory
+	#   dpkg: subprocess gcc --print-libgcc-file-name returned error exit status 2
+	echo 'i386'
+	# (we don't support any of "alpha", "m68k", or "sparc"; see http://archive.debian.org/debian/dists/slink/ -- if we ever do, "apt-get --version" is a good candidate for scraping: "apt 0.3.11 for i386 compiled on Aug  8 1999  10:12:36")
+	exit
+fi
+
 arch="$("$thisDir/debuerreotype-chroot" "$targetDir" dpkg --print-architecture)"
 
 # --debian-eol woody likes to give us "i386-none"

--- a/scripts/debuerreotype-chroot
+++ b/scripts/debuerreotype-chroot
@@ -26,11 +26,13 @@ export targetDir epoch
 unshare --mount bash -Eeuo pipefail -c '
 	[ -n "$targetDir" ] # just to be safe
 	for dir in dev proc sys; do
-		if [ -e "$targetDir/$dir" ]; then
+		if [ -d "$targetDir/$dir" ]; then
 			# --debian-eol woody and below have no /sys
 			mount --rbind "/$dir" "$targetDir/$dir"
 		fi
 	done
-	mount --rbind --read-only /etc/resolv.conf "$targetDir/etc/resolv.conf"
+	if [ -f "$targetDir/etc/resolv.conf" ]; then
+		mount --rbind --read-only /etc/resolv.conf "$targetDir/etc/resolv.conf"
+	fi
 	exec chroot "$targetDir" /usr/bin/env -i PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" TZ="$TZ" LC_ALL="$LC_ALL" SOURCE_DATE_EPOCH="$epoch" "$@"
 ' -- "$cmd" "$@"

--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -106,20 +106,17 @@ else
 	debootstrapArgs+=( --no-check-gpg )
 fi
 
-minbaseSupported="$(
-	scriptFile="$(
-		if [ -n "$script" ]; then
-			readlink -vf "$script"
-		else
-			cd /usr/share/debootstrap/scripts
-			readlink -vf "$suite"
-		fi
-	)"
-	if grep -q 'minbase' "$scriptFile"; then
-		echo 1
+: "${script:=$suite}"
+script="$(
+	if [ -s "$thisDir/.debootstrap-scripts/$script" ]; then
+		readlink -vf "$thisDir/.debootstrap-scripts/$script"
+	elif [ -s "/usr/share/debootstrap/scripts/$script" ]; then
+		readlink -vf "/usr/share/debootstrap/scripts/$script"
+	else
+		readlink -vf "$script"
 	fi
 )"
-if [ -n "$minbaseSupported" ]; then
+if grep -q 'minbase' "$script"; then
 	# --debian-eol sarge and older do not support minbase
 	debootstrapArgs+=( --variant=minbase )
 fi
@@ -131,9 +128,8 @@ fi
 [ -z "$exclude" ] || debootstrapArgs+=( --exclude="$exclude" )
 
 debootstrapArgs+=(
-	"$suite" "$targetDir" "$mirror"
+	"$suite" "$targetDir" "$mirror" "$script"
 )
-[ -z "$script" ] || debootstrapArgs+=( "$script" )
 
 unshare-debootstrap() {
 	# avoid bugs in packages that might leave things mounted ("/run/shm" is a common one that sometimes ends up dangling)

--- a/scripts/debuerreotype-minimizing-config
+++ b/scripts/debuerreotype-minimizing-config
@@ -20,6 +20,7 @@ targetDir="${1:-}"; shift || eusage 'missing target-dir'
 [ -n "$targetDir" ]
 
 aptVersion="$("$thisDir/.apt-version.sh" "$targetDir")"
+dpkgVersion="$("$thisDir/.apt-version.sh" "$targetDir" 'dpkg')"
 
 # https://github.com/docker/docker/blob/d6f4fe9e38b60f63e429fff7ffced9c26cbf8236/contrib/mkimage/debootstrap#L63-L177
 
@@ -43,8 +44,9 @@ if "$thisDir/debuerreotype-chroot" "$targetDir" apt-get install -qq -s upstart &
 fi
 
 # force dpkg not to call sync() after package extraction (speeding up installs)
-if [ -d "$targetDir/etc/dpkg/dpkg.cfg.d" ]; then
+if [ -d "$targetDir/etc/dpkg/dpkg.cfg.d" ] && dpkg --compare-versions "$dpkgVersion" '>=' '1.15.8.6~'; then
 	# --debian-eol lenny and older do not include /etc/dpkg/dpkg.cfg.d
+	# force-unsafe-io was added in dpkg 1.15.8.6: https://salsa.debian.org/dpkg-team/dpkg/-/commit/929a9c4808c79781469987585f78f07df7f1d484
 	cat > "$targetDir/etc/dpkg/dpkg.cfg.d/docker-apt-speedup" <<-'EOF'
 		# For most Docker users, package installs happen during "docker build", which
 		# doesn't survive power loss and gets restarted clean afterwards anyhow, so
@@ -122,7 +124,7 @@ if [ -d "$targetDir/etc/apt/apt.conf.d" ]; then
 	EOF
 	# https://github.com/debuerreotype/debuerreotype/issues/41
 	isDebianJessie="$([ -f "$targetDir/etc/os-release" ] && source "$targetDir/etc/os-release" && [ "${ID:-}" = 'debian' ] && [ "${VERSION_ID:-}" = '8' ] && echo '1')" || :
-	if [ -n "$isDebianJessie" ] || [[ "$aptVersion" == 0.* ]] || "$thisDir/debuerreotype-chroot" "$targetDir" dpkg --compare-versions "$aptVersion" '<<' '1.0.9.2~'; then
+	if [ -n "$isDebianJessie" ] || [[ "$aptVersion" == 0.* ]] || dpkg --compare-versions "$aptVersion" '<<' '1.0.9.2~'; then
 		cat >> "$targetDir/etc/apt/apt.conf.d/docker-gzip-indexes" <<-'EOF'
 
 			# https://salsa.debian.org/apt-team/apt/commit/b0f4b486e6850c5f98520ccf19da71d0ed748ae4; released in src:apt 1.0.9.2, 2014-10-02

--- a/scripts/debuerreotype-slimify
+++ b/scripts/debuerreotype-slimify
@@ -19,6 +19,15 @@ done
 targetDir="${1:-}"; shift || eusage 'missing target-dir'
 [ -n "$targetDir" ]
 
+dpkgVersion="$("$thisDir/.apt-version.sh" "$targetDir" 'dpkg')"
+
+if ! { [ -d "$targetDir/etc/dpkg/dpkg.cfg.d" ] && dpkg --compare-versions "$dpkgVersion" '>=' '1.15.8.6~'; }; then
+	# --debian-eol lenny and older do not include /etc/dpkg/dpkg.cfg.d
+	# path-exclude/include was added in dpkg 1.15.8: https://salsa.debian.org/dpkg-team/dpkg/-/commit/4694cd64089bc72975d8ba6fbe51339023eb2e8c
+	echo >&2 "note: skipping $self: dpkg version ($dpkgVersion) too old to support path-exclude"
+	exit
+fi
+
 # https://github.com/debuerreotype/debuerreotype/issues/10
 shopt -s nullglob
 extraSpecialDirectories=( "$targetDir"/usr/share/man/man[0-9]/ )


### PR DESCRIPTION
This depends on https://salsa.debian.org/installer-team/debootstrap/-/merge_requests/63 (which is included in our `Dockerfile` here) and likely requires running on an actual 32bit system (otherwise it'll fail with inode-too-large issues on either the target rootfs or even in reading files from `/proc` if your target rootfs is 32bit; see https://github.com/moby/moby/issues/5364#issuecomment-480312843).