### PR TITLE
Add initial stab at deb822-style sources.list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,15 @@ jobs:
           - { SUITE: eol, CODENAME: woody, ARCH: i386, TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: f80833896e141fbfebf8c91e79da2ccca1bdeb8f8ecc4e05dd33531c32857e0f }
           - { SUITE: eol, CODENAME: jessie, TIMESTAMP: "2021-03-01T00:00:00Z", SHA256: 45c5553e989a8d42106029ec6f5e042bf48b29e08bf50e414f99f04c33b10fe9 }
 
+          # deb822 testing
+          - { SUITE: unstable, CODENAME: "", TIMESTAMP: "2022-06-30T00:00:00Z", SHA256: 6e781f82630cf92e68ce206a5363983be6b05fff0270de5d1839bcd5e2c415fd }
+          - { SUITE: bookworm, CODENAME: "", TIMESTAMP: "2022-06-30T00:00:00Z", SHA256: 2c8382c35c735217e66f51fd4634bb2f4d89cd0119af2151d320ecb677cb6b20 }
+          - { SUITE: bullseye, CODENAME: "", TIMESTAMP: "2022-06-30T00:00:00Z", SHA256: 2e65c32660eb2035874444de9e11223f34429712a7b6255f13127a3506e2bcb1 }
+
           # qemu-debootstrap testing
           - { ARCH: arm64,   SUITE: jessie,   CODENAME: "", TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 45b3c398b472ff45399cc6cc633005f48d2359d0df8d905022d37a29434420cf }
-          - { ARCH: sh4,     SUITE: unstable, CODENAME: "", TIMESTAMP: "2022-02-01T00:00:00Z", SHA256: 82949d1099c18dd13bd2d732238d94ae70d03abc50afc6950baee257cce37fd1 }
-          - { ARCH: riscv64, SUITE: unstable, CODENAME: "", TIMESTAMP: "2022-02-01T00:00:00Z", SHA256: 2a4accea7aef15d4979435ec16f898dcb784330b7b4991fc9ca38b11f87035f5 }
+          - { ARCH: sh4,     SUITE: unstable, CODENAME: "", TIMESTAMP: "2022-02-01T00:00:00Z", SHA256: 8cf5ac04cd174465aff38484b0cd1b5ad83fe14585322f99a7db404b6dc02275 }
+          - { ARCH: riscv64, SUITE: unstable, CODENAME: "", TIMESTAMP: "2022-02-01T00:00:00Z", SHA256: 3f0d1dc0cb525aa47e6d9947fa7d6e207f7fd72a1d023872a874d6202e020232 }
 
           # a few entries for "today" to try and catch issues like https://github.com/debuerreotype/debuerreotype/issues/41 sooner
           - { SUITE: unstable,  CODENAME: "", TIMESTAMP: "today 00:00:00", SHA256: "" }

--- a/scripts/debuerreotype-debian-sources-list
+++ b/scripts/debuerreotype-debian-sources-list
@@ -5,8 +5,9 @@ thisDir="$(dirname "$(readlink -vf "$BASH_SOURCE")")"
 source "$thisDir/.constants.sh" \
 	--flags 'eol,ports,snapshot' \
 	--flags 'deb-src' \
+	--flags 'deb822,no-deb822' \
 	-- \
-	'[--deb-src] [--eol] [--ports] [--snapshot] <target-dir> <suite>' \
+	'[--deb-src] [--deb822/--no-deb822] [--eol] [--ports] [--snapshot] <target-dir> <suite>' \
 	'--snapshot rootfs stretch
 --eol rootfs wheezy'
 
@@ -15,6 +16,7 @@ eol=
 ports=
 snapshot=
 debSrc=
+deb822='auto'
 while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
@@ -23,6 +25,8 @@ while true; do
 		--ports) ports=1 ;;
 		--snapshot) snapshot=1 ;;
 		--deb-src) debSrc=1 ;;
+		--deb822) deb822=1 ;;
+		--no-deb822) deb822= ;;
 		--) break ;;
 		*) eusage "unknown flag '$flag'" ;;
 	esac
@@ -37,10 +41,29 @@ epoch="$(< "$targetDir/debuerreotype-epoch")"
 comp='main'
 arch="$("$thisDir/.dpkg-arch.sh" "$targetDir")"
 
-deb() {
-	local suite="$1"; shift
-	local comp="$1"; shift
+if [ "$deb822" = 'auto' ]; then
+	aptVersion="$("$thisDir/.apt-version.sh" "$targetDir")"
+	if dpkg --compare-versions "$aptVersion" '>=' '2.3~'; then # this is a minimally-supported version for the files we generate (could go lower, but this is a safe choice) - this exists to support "debuerreotype-init" needing to generate (after "debootstrap" but before the script finishes), and is then overridden by "examples/debian.sh" later with more specific opinions on which releases should be deb822
+		deb822=1
+	else
+		deb822=
+	fi
+fi
 
+if [ -n "$deb822" ]; then
+	if [ -n "$ports" ]; then
+		keyring='debian-ports-archive-keyring.gpg'
+	else
+		keyring='debian-archive-keyring.gpg'
+	fi
+	keyring="/usr/share/keyrings/$keyring"
+	if [ ! -s "$targetDir$keyring" ]; then
+		echo >&2 "warning: it appears that '$targetDir' is missing '$keyring' (the expected keyring for APT); skipping 'Signed-By:' in generated sources"
+		keyring=
+	fi
+fi
+
+deb() {
 	local mirrorArgs=()
 	if [ -n "$ports" ]; then
 		mirrorArgs+=( --ports )
@@ -48,57 +71,114 @@ deb() {
 	if [ -n "$eol" ]; then
 		mirrorArgs+=( --eol )
 	fi
-	mirrorArgs+=( "@$epoch" "$suite" "$arch" "$comp" )
-	local mirrors
-	if ! mirrors="$("$thisDir/.debian-mirror.sh" "${mirrorArgs[@]}")"; then
-		echo >&2 "skipping '$suite/$comp' ..."
-		return
-	fi
-	eval "$mirrors"
-	[ -n "$mirror" ]
-	[ -n "$snapshotMirror" ]
-	[ -n "$foundSuite" ]
-	suite="$foundSuite"
+	mirrorArgs+=( "@$epoch" )
 
-	if [ -n "$snapshot" ]; then
-		mirror="$snapshotMirror"
-	else
-		echo "# deb $snapshotMirror $suite $comp"
-	fi
-	echo "deb $mirror $suite $comp"
-	if [ -n "$debSrc" ]; then
-		echo "deb-src $mirror $suite $comp"
+	local suite deb822Mirrors=()
+	local -A deb822Suites=() deb822Snapshots=()
+	for suite; do
+		local mirrors
+		if ! mirrors="$("$thisDir/.debian-mirror.sh" "${mirrorArgs[@]}" "$suite" "$arch" "$comp")"; then
+			echo >&2 "skipping '$suite/$comp' ..."
+			return
+		fi
+		local mirror snapshotMirror foundSuite
+		eval "$mirrors"
+		[ -n "$mirror" ]
+		[ -n "$snapshotMirror" ]
+		[ -n "$foundSuite" ]
+		suite="$foundSuite"
+
+		if [ -n "$snapshot" ]; then
+			mirror="$snapshotMirror"
+		fi
+
+		if [ -n "$deb822" ]; then
+			if [ -z "${deb822Suites["$mirror"]:-}" ]; then
+				# haven't seen this mirror yet!
+				deb822Mirrors+=( "$mirror" )
+				deb822Snapshots["$mirror"]="$snapshotMirror"
+			fi
+			deb822Suites["$mirror"]+="${deb822Suites["$mirror"]:+ }$suite"
+		else
+			if [ -z "$snapshot" ]; then
+				echo "# deb $snapshotMirror $suite $comp"
+			fi
+			echo "deb $mirror $suite $comp"
+			if [ -n "$debSrc" ]; then
+				echo "deb-src $mirror $suite $comp"
+			fi
+		fi
+	done
+
+	if [ -n "$deb822" ]; then
+		local first=1
+		local mirror
+		for mirror in "${deb822Mirrors[@]}"; do
+			if [ -n "$first" ]; then
+				first=
+			else
+				echo
+			fi
+			if [ -n "$debSrc" ]; then
+				echo 'Types: deb deb-src'
+			else
+				echo 'Types: deb'
+			fi
+			if [ -z "$snapshot" ]; then
+				echo "# ${deb822Snapshots["$mirror"]}"
+			fi
+			echo "URIs: $mirror"
+			echo "Suites: ${deb822Suites["$mirror"]}"
+			echo "Components: $comp"
+			if [ -n "$keyring" ]; then
+				echo "Signed-By: $keyring"
+			fi
+		done
 	fi
 }
 
+targetFileLine='/etc/apt/sources.list'
+targetFile822='/etc/apt/sources.list.d/debian.sources'
+if [ -n "$deb822" ]; then
+	targetFile="$targetFile822"
+	rm -f "$targetDir$targetFileLine"
+else
+	targetFile="$targetFileLine"
+	rm -f "$targetDir$targetFile822"
+fi
+unset targetFileLine targetFile822
+
 # https://github.com/tianon/go-aptsources/blob/e066ed9cd8cd9eef7198765bd00ec99679e6d0be/target.go#L16-L58
 {
+	suites=( "$suite" )
 	case "$suite" in
-		sid | unstable | testing)
-			deb "$suite" "$comp" standard
+		sid | unstable)
 			if [ -n "$ports" ]; then
 				# https://www.ports.debian.org/archive
-				deb unreleased "$comp" standard
+				suites+=( 'unreleased' )
 			fi
 			;;
 
 		*)
+			# https://salsa.debian.org/apt-team/apt/-/blob/23fe896858dfc7857f2d59c5fd7627332f11c1ff/vendor/debian/apt-vendor.ent#L9-20
 			# https://salsa.debian.org/installer-team/apt-setup/tree/d7a642fb5fc76e4f0b684db53984bdb9123f8360/generators
-			deb "$suite"          "$comp" standard # "50mirror"
-			deb "$suite-security" "$comp" security # "91security"
-			deb "$suite-updates"  "$comp" standard # "92updates"
+			# https://github.com/debuerreotype/debuerreotype/pull/128#issuecomment-1164046315
 			# https://wiki.debian.org/SourcesList#Example_sources.list
-
+			suites+=(
+				"$suite-security"
+				"$suite-updates"
+			)
 			if [ "$suite" = 'squeeze' ]; then
 				# https://wiki.debian.org/DebianSqueeze#FAQ
-				deb "$suite-lts" "$comp" standard
+				suites+=( "$suite-lts" )
 			fi
 			;;
 	esac
-} > "$targetDir/etc/apt/sources.list"
-chmod 0644 "$targetDir/etc/apt/sources.list"
+	deb "${suites[@]}"
+} > "$targetDir$targetFile"
+chmod 0644 "$targetDir$targetFile"
 
-if [ ! -s "$targetDir/etc/apt/sources.list" ]; then
-	echo >&2 "error: sources.list ended up empty -- something is definitely wrong"
+if [ ! -s "$targetDir$targetFile" ]; then
+	echo >&2 "error: '$targetFile' ended up empty -- something is definitely wrong"
 	exit 1
 fi


### PR DESCRIPTION
The intention is to start with *just* unstable for a month or two, but the goal is to include this in bookworm+ (so it will hit testing images eventually).

See https://lists.debian.org/debian-devel/2021/11/msg00026.html for some discussion around this.

cc @julian-klode

Here's an example of forcing the generation for `bookworm`:

```yaml
Types: deb
# http://snapshot.debian.org/archive/debian/20220131T000000Z
URIs: http://deb.debian.org/debian
Suites: bookworm
Components: main
Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg

Types: deb
# http://snapshot.debian.org/archive/debian-security/20220131T000000Z
URIs: http://security.debian.org/debian-security
Suites: bookworm-security
Components: main
Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg

Types: deb
# http://snapshot.debian.org/archive/debian/20220131T000000Z
URIs: http://deb.debian.org/debian
Suites: bookworm-updates
Components: main
Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
```

(The generated file for `unstable` is a lot less interesting as it's only a single entry.)