### PR TITLE
Adjust "fixup" to empty machine-id and "examples/debian.sh" to exclude it entirely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,25 +26,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - { SUITE: stable,    CODENAME: jessie,  TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 55ba54fdca819df18d813be36503b0a02abf1570c3bf5999b10891ccca5448e2 }
-          - { SUITE: jessie,    CODENAME: "",      TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 55ba54fdca819df18d813be36503b0a02abf1570c3bf5999b10891ccca5448e2 }
-          - { SUITE: testing,   CODENAME: stretch, TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 1608c820c1d9c9d8adf210f80b1d751e5c26179aa27a1c1ddb8e41ae0222d8c4 }
-          - { SUITE: stretch,   CODENAME: "",      TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 1608c820c1d9c9d8adf210f80b1d751e5c26179aa27a1c1ddb8e41ae0222d8c4 }
-          - { SUITE: unstable,  CODENAME: sid,     TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 49a5152822ec9f0e1a61ff1d02671681f12fc1aba083f39e972f6ff897b69c80 }
-          - { SUITE: sid,       CODENAME: "",      TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 49a5152822ec9f0e1a61ff1d02671681f12fc1aba083f39e972f6ff897b69c80 }
-          - { SUITE: oldstable, CODENAME: wheezy,  TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: f1bd72548e3c25ce222fb9e2bb57a5b6d4b01042180894fb05d83a0251e6dab1 }
-          - { SUITE: wheezy,    CODENAME: "",      TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: f1bd72548e3c25ce222fb9e2bb57a5b6d4b01042180894fb05d83a0251e6dab1 }
+          - { SUITE: stable,    CODENAME: jessie,  TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: a712fb9b228f107a0d65e836127a377857ab70388f2e23d3b583ac56f8f5a75b }
+          - { SUITE: jessie,    CODENAME: "",      TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: a712fb9b228f107a0d65e836127a377857ab70388f2e23d3b583ac56f8f5a75b }
+          - { SUITE: testing,   CODENAME: stretch, TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 56adf91c1aca0b52ba7c818f4cdc93e47a6c2c93266296d7e0e108ddead825b4 }
+          - { SUITE: stretch,   CODENAME: "",      TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 56adf91c1aca0b52ba7c818f4cdc93e47a6c2c93266296d7e0e108ddead825b4 }
+          - { SUITE: unstable,  CODENAME: sid,     TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 87f46eeb98d44ff5742d87112d9cc45e51dbb1204d60cb4136b51f0edfce061f }
+          - { SUITE: sid,       CODENAME: "",      TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 87f46eeb98d44ff5742d87112d9cc45e51dbb1204d60cb4136b51f0edfce061f }
+          - { SUITE: oldstable, CODENAME: wheezy,  TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 52f942d1d0f5ed2d41cb81b63091dc5da0872da94b80a684937cdab7fc57ac06 }
+          - { SUITE: wheezy,    CODENAME: "",      TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 52f942d1d0f5ed2d41cb81b63091dc5da0872da94b80a684937cdab7fc57ac06 }
 
           # EOL suites testing
-          - { SUITE: eol, CODENAME: etch,  TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: b48e999ab4fda1720b0dc863d38cdd4d6b55530f34f262a28949eb6173102da9 }
-          - { SUITE: eol, CODENAME: lenny, TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 17c39f770990427e85369c6008eb13f84c63e4565fcc631bcd0cf5a27ed8ab78 }
-          - { SUITE: eol, CODENAME: woody, ARCH: i386, TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: ef4bc81e31db51fa9f095811ddbcc8a005f05f098596317d5a138fa90157bf40 }
-          - { SUITE: eol, CODENAME: jessie, TIMESTAMP: "2021-03-01T00:00:00Z", SHA256: 7709f5447e568b052a541e71d7c57a29c47264fc3656eeb96d886e3d2897717f }
+          - { SUITE: eol, CODENAME: etch,  TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 893d436a060f2536f70efbdfd2e2952cf311eada558f858e6190c80b323b783e }
+          - { SUITE: eol, CODENAME: lenny, TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: c263084bc482b1538512eb091095dd30cf55a6873b989aeee9d4e148f2f3fafa }
+          - { SUITE: eol, CODENAME: woody, ARCH: i386, TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: f80833896e141fbfebf8c91e79da2ccca1bdeb8f8ecc4e05dd33531c32857e0f }
+          - { SUITE: eol, CODENAME: jessie, TIMESTAMP: "2021-03-01T00:00:00Z", SHA256: a151dd2b4209e152c9323778e3d1016b26e89881df7dd3d81a39282cbd37bdae }
 
           # qemu-debootstrap testing
-          - { ARCH: arm64,   SUITE: jessie,   CODENAME: "", TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: 893efc1b9db1ba2df4f171d4422194a408f9810d3b55d9b0cd66fcc7722f7567 }
-          - { ARCH: sh4,     SUITE: unstable, CODENAME: "", TIMESTAMP: "2022-02-01T00:00:00Z", SHA256: 220c548084bb1f2d8d1517558b3999d2bc8814594a3be7817aeb29f20678bb44 }
-          - { ARCH: riscv64, SUITE: unstable, CODENAME: "", TIMESTAMP: "2022-02-01T00:00:00Z", SHA256: 4c1483539e8ff58b920f13ed2e3060e915633cbffb3b0bad661b9821c7b11b8d }
+          - { ARCH: arm64,   SUITE: jessie,   CODENAME: "", TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: e0bbe759a5df8a3201c3bfc984a91d7ee46bb7cb939d7c06275ff374043ed731 }
+          - { ARCH: sh4,     SUITE: unstable, CODENAME: "", TIMESTAMP: "2022-02-01T00:00:00Z", SHA256: 82949d1099c18dd13bd2d732238d94ae70d03abc50afc6950baee257cce37fd1 }
+          - { ARCH: riscv64, SUITE: unstable, CODENAME: "", TIMESTAMP: "2022-02-01T00:00:00Z", SHA256: 2a4accea7aef15d4979435ec16f898dcb784330b7b4991fc9ca38b11f87035f5 }
 
           # a few entries for "today" to try and catch issues like https://github.com/debuerreotype/debuerreotype/issues/41 sooner
           - { SUITE: unstable,  CODENAME: "", TIMESTAMP: "today 00:00:00", SHA256: "" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,11 @@ WORKDIR /tmp
 # debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.gpg test-stretch stretch 2017-05-08T00:00:00Z
 # debuerreotype-tar test-stretch test-stretch.tar
 # md5sum test-stretch.tar
-#   14206d5b9b2991e98f5214c3d310e4fa
+#   694f02c53651673ebe094cae3bcbb06d
 # ./docker-run.sh sh -euxc 'debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.gpg /tmp/rootfs stretch 2017-05-08T00:00:00Z; debuerreotype-tar /tmp/rootfs - | md5sum'
 
 # debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.gpg test-jessie jessie 2017-05-08T00:00:00Z
 # debuerreotype-tar test-jessie test-jessie.tar
 # md5sum test-jessie.tar
-#   a5b38410ca3f519117966a33474f1267
+#   354cedd99c08d213d3493a7cf0aaaad6
 # ./docker-run.sh sh -euxc 'debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.gpg /tmp/rootfs jessie 2017-05-08T00:00:00Z; debuerreotype-tar /tmp/rootfs - | md5sum'

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Processing triggers for libc-bin (2.24-8) ...
 $ debuerreotype-debian-sources-list rootfs stretch
 
 $ debuerreotype-tar rootfs - | sha256sum
-a076d4cd04f68ee117e598a40cc947ad051fc8b063340da015fdceddeb1b0e75  -
+e6f10da22f7ab5996f855c85ad5ae38cd786029c57893436c3bb2320f30bc188  -
 
 $ # try it!  you should get that same sha256sum value!
 ```

--- a/examples/debian.sh
+++ b/examples/debian.sh
@@ -256,7 +256,11 @@ create_artifacts() {
 
 	debuerreotype-debian-sources-list "${sourcesListArgs[@]}" "$rootfs" "$suite"
 
-	local tarArgs=()
+	local tarArgs=(
+		# https://www.freedesktop.org/software/systemd/man/machine-id.html
+		--exclude ./etc/machine-id
+		# "debuerreotype-fixup" will make this an empty file for reproducibility, but for our Docker images it seems more appropriate for it to not exist (since they've never actually been "booted" so having the "first boot" logic trigger if someone were to run systemd in them conceptually makes sense)
+	)
 
 	case "$suite" in
 		sarge) # 3.1

--- a/scripts/debuerreotype-fixup
+++ b/scripts/debuerreotype-fixup
@@ -21,6 +21,13 @@ targetDir="${1:-}"; shift || eusage 'missing target-dir'
 epoch="$(< "$targetDir/debuerreotype-epoch")"
 [ -n "$epoch" ]
 
+if [ -s "$targetDir/etc/machine-id" ]; then
+	# https://www.freedesktop.org/software/systemd/man/machine-id.html
+	# > For operating system images which are created once and used on multiple machines, for example for containers or in the cloud, /etc/machine-id should be either missing or an empty file in the generic file system image ...
+	echo -n > "$targetDir/etc/machine-id"
+	chmod 0644 "$targetDir/etc/machine-id"
+fi
+
 # https://github.com/lamby/debootstrap/commit/66b15380814aa62ca4b5807270ac57a3c8a0558d#diff-de4eef4ab836e5c6c9c1f820a2f624baR709
 rm -f \
 	"$targetDir/var/log/dpkg.log" \

--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -179,10 +179,6 @@ fi
 ' -- "$include"
 
 echo 'debuerreotype' > "$targetDir/etc/hostname"
-echo "$epoch" \
-	| md5sum \
-	| cut -f1 -d' ' \
-	> "$targetDir/etc/machine-id" # TODO should we only do this if "/etc/machine-id" already exists?
 {
 	echo '# https://1.1.1.1 (privacy-focused, highly-available DNS service)'
 	echo 'nameserver 1.1.1.1'
@@ -190,7 +186,6 @@ echo "$epoch" \
 } > "$targetDir/etc/resolv.conf"
 chmod 0644 \
 	"$targetDir/etc/hostname" \
-	"$targetDir/etc/machine-id" \
 	"$targetDir/etc/resolv.conf"
 
 # fix ownership/permissions on / (otherwise "debootstrap" leaves them as-is which causes reproducibility issues)


### PR DESCRIPTION
See also https://www.freedesktop.org/software/systemd/man/machine-id.html for more detail.

```diff
$ diffoscope validate.bak/20220201/riscv64/unstable/rootfs.tar.xz validate/20220201/riscv64/unstable/rootfs.tar.xz
--- validate.bak/20220201/riscv64/unstable/rootfs.tar.xz
+++ validate/20220201/riscv64/unstable/rootfs.tar.xz
├── rootfs.tar
│ ├── file list
│ │ @@ -166,15 +166,14 @@
│ │  -rw-r--r--   0        0        0      191 2021-10-09 09:45:31.000000 etc/libaudit.conf
│ │  lrwxrwxrwx   0        0        0        0 2022-02-01 00:00:00.000000 etc/localtime -> /usr/share/zoneinfo/Etc/UTC
│ │  -rw-r--r--   0        0        0    11876 2022-01-31 09:33:28.000000 etc/login.defs
│ │  drwxr-xr-x   0        0        0        0 2022-02-01 00:00:00.000000 etc/logrotate.d/
│ │  -rw-r--r--   0        0        0      120 2021-09-11 18:35:03.000000 etc/logrotate.d/alternatives
│ │  -rw-r--r--   0        0        0      173 2022-01-06 19:57:39.000000 etc/logrotate.d/apt
│ │  -rw-r--r--   0        0        0      112 2021-09-11 18:35:03.000000 etc/logrotate.d/dpkg
│ │ --rw-r--r--   0        0        0       33 2022-02-01 00:00:00.000000 etc/machine-id
│ │  -rw-r--r--   0        0        0      782 2022-01-04 04:48:13.000000 etc/mke2fs.conf
│ │  -rw-r--r--   0        0        0      286 2022-01-19 22:35:00.000000 etc/motd
│ │  -rw-r--r--   0        0        0      767 2021-08-17 15:16:38.000000 etc/netconfig
│ │  -rw-r--r--   0        0        0      494 2019-08-16 10:57:32.000000 etc/nsswitch.conf
│ │  drwxr-xr-x   0        0        0        0 2022-02-01 00:00:00.000000 etc/opt/
│ │  lrwxrwxrwx   0        0        0        0 2022-01-19 22:35:00.000000 etc/os-release -> ../usr/lib/os-release
│ │  -rw-r--r--   0        0        0      552 2020-08-12 00:15:04.000000 etc/pam.conf
```

Closes https://github.com/debuerreotype/docker-debian-artifacts/issues/151