### PR TITLE
Make DEBIAN_FRONTEND useable and support apt-cacher

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -67,6 +67,9 @@ args=(
 	--tmpfs /tmp:dev,exec,suid,noatime
 	--env TMPDIR=/tmp
 
+	# if "http_proxy" is set, pass it through (especially for APT cache)
+	--env http_proxy
+
 	--workdir /workdir
 )
 if [ -n "$bindMount" ]; then

--- a/scripts/debuerreotype-chroot
+++ b/scripts/debuerreotype-chroot
@@ -34,5 +34,11 @@ unshare --mount bash -Eeuo pipefail -c '
 	if [ -f "$targetDir/etc/resolv.conf" ]; then
 		mount --rbind --read-only /etc/resolv.conf "$targetDir/etc/resolv.conf"
 	fi
-	exec chroot "$targetDir" /usr/bin/env -i PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" TZ="$TZ" LC_ALL="$LC_ALL" SOURCE_DATE_EPOCH="$epoch" "$@"
+	exec chroot "$targetDir" /usr/bin/env -i \
+		PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+		TZ="$TZ" \
+		LC_ALL="$LC_ALL" \
+		${http_proxy:+http_proxy="$http_proxy"} \
+		SOURCE_DATE_EPOCH="$epoch" \
+		"$@"
 ' -- "$cmd" "$@"

--- a/scripts/debuerreotype-chroot
+++ b/scripts/debuerreotype-chroot
@@ -39,6 +39,7 @@ unshare --mount bash -Eeuo pipefail -c '
 		TZ="$TZ" \
 		LC_ALL="$LC_ALL" \
 		${http_proxy:+http_proxy="$http_proxy"} \
+		${DEBIAN_FRONTEND:+DEBIAN_FRONTEND="$DEBIAN_FRONTEND"} \
 		SOURCE_DATE_EPOCH="$epoch" \
 		"$@"
 ' -- "$cmd" "$@"


### PR DESCRIPTION
Hi.
While updating my base images, I tend to build a lot of images and hack `APT_PROXY` into debuerreotype to make use of apt-cacher-ng. So, here's a patch for that.

I also noticed that setting `DEBIAN_FRONTEND=noninteractive` in a script does nothing because inside of `debuerreotype-chroot` we clear the environment and don't forward that. This makes `debuerreotype-apt-get install` fail on packages that want to be configured, e.g. `console-setup`.