### PR TITLE
Add "rootfs.debootstrap-version" as another output file

### DIFF
--- a/examples/debian.sh
+++ b/examples/debian.sh
@@ -346,7 +346,10 @@ create_artifacts() {
 	echo "$epoch" > "$targetBase.debuerreotype-epoch"
 	echo "$variant" > "$targetBase.debuerreotype-variant"
 	debuerreotype-version > "$targetBase.debuerreotype-version"
-	touch_epoch "$targetBase".{manifest,apt-dist,dpkg-arch,debuerreotype-*}
+	debootstrapVersion="$(debootstrap --version)"
+	debootstrapVersion="${debootstrapVersion#debootstrap }" # "debootstrap X.Y.Z" -> "X.Y.Z"
+	echo "$debootstrapVersion" > "$targetBase.debootstrap-version"
+	touch_epoch "$targetBase".{manifest,apt-dist,dpkg-arch,debuerreotype-*,debootstrap-version}
 
 	for f in /etc/debian_version /etc/os-release "$sourcesListFile"; do
 		targetFile="$(_sanitize_basename "$f")"

--- a/examples/raspbian.sh
+++ b/examples/raspbian.sh
@@ -165,7 +165,10 @@ create_artifacts() {
 	echo "$epoch" > "$targetBase.debuerreotype-epoch"
 	echo "$variant" > "$targetBase.debuerreotype-variant"
 	debuerreotype-version > "$targetBase.debuerreotype-version"
-	touch_epoch "$targetBase".{manifest,apt-dist,dpkg-arch,debuerreotype-*}
+	debootstrapVersion="$(debootstrap --version)"
+	debootstrapVersion="${debootstrapVersion#debootstrap }" # "debootstrap X.Y.Z" -> "X.Y.Z"
+	echo "$debootstrapVersion" > "$targetBase.debootstrap-version"
+	touch_epoch "$targetBase".{manifest,apt-dist,dpkg-arch,debuerreotype-*,debootstrap-version}
 
 	for f in debian_version os-release apt/sources.list; do
 		targetFile="$targetBase.$(basename "$f" | sed -r "s/[^a-zA-Z0-9_-]+/-/g")"

--- a/examples/steamos.sh
+++ b/examples/steamos.sh
@@ -151,7 +151,10 @@ create_artifacts() {
 	echo "$epoch" > "$targetBase.debuerreotype-epoch"
 	echo "$variant" > "$targetBase.debuerreotype-variant"
 	debuerreotype-version > "$targetBase.debuerreotype-version"
-	touch_epoch "$targetBase".{manifest,apt-dist,dpkg-arch,debuerreotype-*}
+	debootstrapVersion="$(debootstrap --version)"
+	debootstrapVersion="${debootstrapVersion#debootstrap }" # "debootstrap X.Y.Z" -> "X.Y.Z"
+	echo "$debootstrapVersion" > "$targetBase.debootstrap-version"
+	touch_epoch "$targetBase".{manifest,apt-dist,dpkg-arch,debuerreotype-*,debootstrap-version}
 
 	for f in debian_version os-release apt/sources.list; do
 		targetFile="$targetBase.$(basename "$f" | sed -r "s/[^a-zA-Z0-9_-]+/-/g")"

--- a/examples/ubuntu.sh
+++ b/examples/ubuntu.sh
@@ -161,7 +161,10 @@ create_artifacts() {
 	echo "$epoch" > "$targetBase.debuerreotype-epoch"
 	echo "$variant" > "$targetBase.debuerreotype-variant"
 	debuerreotype-version > "$targetBase.debuerreotype-version"
-	touch_epoch "$targetBase".{manifest,apt-dist,dpkg-arch,debuerreotype-*}
+	debootstrapVersion="$(debootstrap --version)"
+	debootstrapVersion="${debootstrapVersion#debootstrap }" # "debootstrap X.Y.Z" -> "X.Y.Z"
+	echo "$debootstrapVersion" > "$targetBase.debootstrap-version"
+	touch_epoch "$targetBase".{manifest,apt-dist,dpkg-arch,debuerreotype-*,debootstrap-version}
 
 	for f in debian_version os-release apt/sources.list; do
 		targetFile="$targetBase.$(basename "$f" | sed -r "s/[^a-zA-Z0-9_-]+/-/g")"


### PR DESCRIPTION
This becomes useful for identifying changes in debootstrap that cause reproducibility issues (such as the recent `usr-is-merged` changes; https://github.com/debuerreotype/docker-debian-artifacts/issues/174 / https://salsa.debian.org/installer-team/debootstrap/-/merge_requests/71 / https://salsa.debian.org/installer-team/debootstrap/-/merge_requests/72).

Closes #138