### PR TITLE
Update to deb822-sources for bookworm (previously sid-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
           # deb822 / usr-is-merged testing
           - { SUITE: unstable, CODENAME: "", TIMESTAMP: "2022-09-30T00:00:00Z", SHA256: 03a0c528782513e6d00a4f0e4d6137d5eb308e1b7544e2230d86626861086f1a }
-          - { SUITE: bookworm, CODENAME: "", TIMESTAMP: "2022-09-30T00:00:00Z", SHA256: c4808779c6169f5a6543022ec7233be4d371f071c729fa6f328086ab97aa3021 }
+          - { SUITE: bookworm, CODENAME: "", TIMESTAMP: "2022-09-30T00:00:00Z", SHA256: 8b350357e65dc02f04774c56d4b39b232ba53746a132496a211d3152287f7db2 }
           - { SUITE: bullseye, CODENAME: "", TIMESTAMP: "2022-09-30T00:00:00Z", SHA256: cd39823e09ebc57cc3e6d4d57faa24ea6ddfab60f0519165a26f101ea94f13a0 }
 
           # qemu-debootstrap testing

--- a/examples/debian.sh
+++ b/examples/debian.sh
@@ -220,7 +220,7 @@ aptVersion="$("$debuerreotypeScriptsDir/.apt-version.sh" "$rootfsDir")"
 sourcesListArgs=()
 [ -z "$eol" ] || sourcesListArgs+=( --eol )
 [ -z "$ports" ] || sourcesListArgs+=( --ports )
-if dpkg --compare-versions "$aptVersion" '>=' '2.3~' && { [ "$suite" = 'unstable' ] || [ "$suite" = 'sid' ]; }; then # just unstable for now (TODO after some time testing this, we should update this to bookworm+ which is aptVersion 2.3+)
+if dpkg --compare-versions "$aptVersion" '>=' '2.3~'; then
 	sourcesListArgs+=( --deb822 )
 	sourcesListFile='/etc/apt/sources.list.d/debian.sources'
 else


### PR DESCRIPTION
This is the inevitable follow-up to https://github.com/debuerreotype/debuerreotype/pull/128

@julian-klode I'd love to hear your thoughts on whether you think we're ready to go to this next stage? :bow:
(I haven't heard of much bad breakage, but I imagine you're closer to where those might occur than I am :sweat_smile:)