### PR TITLE
Update distro-info-data to 0.56

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,10 @@ RUN echo 'hsts=0' >> "$WGETRC"
 # https://github.com/debuerreotype/debuerreotype/issues/100
 # https://tracker.debian.org/pkg/distro-info-data
 # http://snapshot.debian.org/package/distro-info-data/
-# http://snapshot.debian.org/package/distro-info-data/0.53/
+# http://snapshot.debian.org/package/distro-info-data/0.56/
 RUN set -eux; \
-	wget -O distro-info-data.deb 'http://snapshot.debian.org/archive/debian/20220425T210133Z/pool/main/d/distro-info-data/distro-info-data_0.53_all.deb'; \
-	echo '9c2044aae46ae3d54927deadaabbdfbd4c4177aa *distro-info-data.deb' | sha1sum --strict --check -; \
+	wget -O distro-info-data.deb 'http://snapshot.debian.org/archive/debian/20221101T030416Z/pool/main/d/distro-info-data/distro-info-data_0.56_all.deb'; \
+	echo 'c882f7dc235bd99ff1c980d4555733ed78e7c631 *distro-info-data.deb' | sha1sum --strict --check -; \
 	apt-get install -y ./distro-info-data.deb; \
 	rm distro-info-data.deb; \
 	[ -s /usr/share/distro-info/debian.csv ]


### PR DESCRIPTION
```markdown
distro-info-data (0.56) unstable; urgency=medium

  [ Stefano Rivera ]
  * Add Debian 14 "forky" with a vague creation date.

  [ Brian Murray ]
  * Correct Update 23.04 release date to 2023-04-20

 -- Benjamin Drung <bdrung@debian.org>  Mon, 31 Oct 2022 14:51:00 +0100

distro-info-data (0.55) unstable; urgency=medium

  [ Stefano Rivera ]
  * Mark python3 Build-Depend as <!nocheck>.

  [ Thomas Bechtold ]
  * Add dates for Ubuntu 23.04, Lunar Lobster (LP: #1993667)

 -- Benjamin Drung <bdrung@debian.org>  Fri, 28 Oct 2022 11:09:05 +0200

distro-info-data (0.54) unstable; urgency=medium

  * Update Debian ELTS dates to ~10 years of support (Closes: #1014837)
  * Correct release date of Debian 8 (jessie) to 2015-04-26
  * Restrict maximum line length to 79 characters
  * Fix all pylint complaints (except too-many-branches)
  * Switch to debhelper 13
  * Bump Standards-Version to 4.6.1 (no changes needed)

 -- Benjamin Drung <bdrung@debian.org>  Sat, 23 Jul 2022 17:31:19 +0200
```