### PR TITLE
Update "oci-image.sh" to allow directory output

### DIFF
--- a/examples/oci-image.sh
+++ b/examples/oci-image.sh
@@ -38,10 +38,10 @@ while true; do
 	esac
 done
 
-targetFile="${1:-}"; shift || eusage 'missing target-file' # "something.tar"
+target="${1:-}"; shift || eusage 'missing target-file' # "something.tar"
 sourceDir="${1:-}"; shift || eusage 'missing source-directory' # "out/YYYYMMDD/ARCH/SUITE{,/slim}"
 
-targetFile="$(readlink -vf "$targetFile")"
+target="$(readlink -vf "$target")"
 if [ -n "$meta" ]; then
 	meta="$(readlink -vf "$meta")"
 fi
@@ -58,34 +58,12 @@ epoch="$(< "$sourceDir/rootfs.debuerreotype-epoch")"
 iso8601="$(date --date="@$epoch" '+%Y-%m-%dT%H:%M:%SZ')"
 export version epoch iso8601
 
-if [ -s "$sourceDir/rootfs.apt-dist" ]; then
-	suite="$(< "$sourceDir/rootfs.apt-dist")"
-	# TODO remove this fallback once debuerreotype 0.13 is released and we can safely assume "rootfs.apt-dist" exists
-else
-	suite="$(awk '$1 == "deb" { print $3; exit }' "$sourceDir/rootfs.sources-list")"
-fi
+suite="$(< "$sourceDir/rootfs.apt-dist")"
 export suite
 
-if [ -s "$sourceDir/rootfs.debuerreotype-variant" ]; then
-	variant="$(< "$sourceDir/rootfs.debuerreotype-variant")"
-	# TODO remove this fallback once debuerreotype 0.13 is released and we can safely assume "rootfs.debuerreotype-variant" exists
-else
-	dirBase="$(basename "$sourceDir")"
-	case "$dirBase" in
-		slim) variant="$dirBase" ;;
-		"$suite") variant='' ;;
-		*) echo >&2 "error: unknown variant: '$variant'"; exit 1 ;;
-	esac
-fi
+variant="$(< "$sourceDir/rootfs.debuerreotype-variant")"
 
-if [ -s "$sourceDir/rootfs.dpkg-arch" ]; then
-	dpkgArch="$(< "$sourceDir/rootfs.dpkg-arch")"
-	# TODO remove these fallbacks once debuerreotype 0.13 is released and we can safely assume "rootfs.dpkg-arch" exists
-elif [ -n "$variant" ]; then # xxx/YYYYMMDD/ARCH/SUITE/slim
-	dpkgArch="$(cd "$sourceDir/../.." && basename "$PWD")"
-else # xxx/YYYYMMDD/ARCH/SUITE
-	dpkgArch="$(cd "$sourceDir/.." && basename "$PWD")"
-fi
+dpkgArch="$(< "$sourceDir/rootfs.dpkg-arch")"
 unset goArch
 goArm=
 case "$dpkgArch" in
@@ -127,7 +105,8 @@ pigz --best --no-time "$tempDir/rootfs.tar"
 rootfsSize="$(stat --format='%s' "$tempDir/rootfs.tar.gz")"
 rootfsSha256="$(_sha256 "$tempDir/rootfs.tar.gz")"
 export rootfsSize rootfsSha256
-mv "$tempDir/rootfs.tar.gz" "$tempDir/oci/blobs/sha256/$rootfsSha256"
+mv "$tempDir/rootfs.tar.gz" "$tempDir/oci/blobs/rootfs.tar.gz"
+ln -sfT ../rootfs.tar.gz "$tempDir/oci/blobs/sha256/$rootfsSha256"
 
 script='debian.sh'
 if [ -x "$thisDir/$osID.sh" ]; then
@@ -184,7 +163,8 @@ jq -ncS '
 configSize="$(stat --format='%s' "$tempDir/config.json")"
 configSha256="$(_sha256 "$tempDir/config.json")"
 export configSize configSha256
-mv "$tempDir/config.json" "$tempDir/oci/blobs/sha256/$configSha256"
+mv "$tempDir/config.json" "$tempDir/oci/blobs/image-config.json"
+ln -sfT ../image-config.json "$tempDir/oci/blobs/sha256/$configSha256"
 
 # https://github.com/opencontainers/image-spec/blob/v1.0.1/manifest.md
 jq -ncS '
@@ -208,7 +188,8 @@ jq -ncS '
 manifestSize="$(stat --format='%s' "$tempDir/manifest.json")"
 manifestSha256="$(_sha256 "$tempDir/manifest.json")"
 export manifestSize manifestSha256
-mv "$tempDir/manifest.json" "$tempDir/oci/blobs/sha256/$manifestSha256"
+mv "$tempDir/manifest.json" "$tempDir/oci/blobs/image-manifest.json"
+ln -sfT ../image-manifest.json "$tempDir/oci/blobs/sha256/$manifestSha256"
 
 export repo="$bashbrewArch/$osID" # "amd64/debian", "arm32v6/raspbian", etc.
 export tag="$suite${variant:+-$variant}" # "buster", "buster-slim", etc.
@@ -251,16 +232,22 @@ find "$tempDir/oci" \
 	-newermt "@$epoch" \
 	-exec touch --no-dereference --date="@$epoch" '{}' +
 
-echo >&2 "generating tarball ($targetFile) ..."
+if [ -d "$target" ]; then
+	# this is an undocumented feature -- if you run the script with an existing directory, it will assume that directory must be where you want the OCI bundle dumped
+	echo >&2 "copying ($target) ..."
+	rsync -a --delete-after "$tempDir/oci/" "$target/"
+else
+	echo >&2 "generating tarball ($target) ..."
 
-tar --create \
-	--auto-compress \
-	--directory "$tempDir/oci" \
-	--file "$targetFile" \
-	--numeric-owner --owner 1000:1000 \
-	--sort name \
-	.
-touch --no-dereference --date="@$epoch" "$targetFile"
+	tar --create \
+		--auto-compress \
+		--directory "$tempDir/oci" \
+		--file "$target" \
+		--numeric-owner --owner 1000:1000 \
+		--sort name \
+		.
+	touch --no-dereference --date="@$epoch" "$target"
+fi
 
 jq -n --argjson platform "$platform" '
 	{


### PR DESCRIPTION
This drops the fallback behaviors that we shouldn't need anymore, allows us to generate our OCI contents to a directory instead of a tarball, and updates our `blobs/sha256/xxx` entries to instead be symlinks to files with better names under `blobs/` (`blobs/image-manifest.json`, etc).

```console
$ find -ls
 42995983      4 drwxrwxr-x   3 tianon   tianon       4096 Oct  2 17:00 .
 42995984      4 drwxrwxr-x   3 tianon   tianon       4096 Oct  2 17:00 ./blobs
 42995989      4 drwxrwxr-x   2 tianon   tianon       4096 Oct  2 17:00 ./blobs/sha256
 42996020      0 lrwxrwxrwx   1 tianon   tianon         16 Oct  2 17:00 ./blobs/sha256/0449b3622c2481758a471eb896afc4f61395ce504b442bc06630f1a16792c54f -> ../rootfs.tar.gz
 42996007      0 lrwxrwxrwx   1 tianon   tianon         22 Oct  2 17:00 ./blobs/sha256/e796f760c82ae1ba99bdc4780b31cd341a6fcd17df5266f1b2274692bc20afed -> ../image-manifest.json
 42996005      0 lrwxrwxrwx   1 tianon   tianon         20 Oct  2 17:00 ./blobs/sha256/1a2ed76cb6224a2389f49e29b55b48f911c26b4680dd711ad51ff53c5a4ecf93 -> ../image-config.json
 42996008      4 -rw-rw-r--   1 tianon   tianon        457 Oct  2 17:00 ./blobs/image-config.json
 42996067      4 -rw-rw-r--   1 tianon   tianon        407 Oct  2 17:00 ./blobs/image-manifest.json
 42996068  27596 -rw-rw-r--   1 tianon   tianon   28257302 Oct  2 17:00 ./blobs/rootfs.tar.gz
 42995995      4 -rw-rw-r--   1 tianon   tianon        360 Oct  2 17:00 ./index.json
 42996003      4 -rw-rw-r--   1 tianon   tianon         31 Oct  2 17:00 ./oci-layout
 42995999      4 -rw-rw-r--   1 tianon   tianon        226 Oct  2 17:00 ./manifest.json
```

(https://github.com/docker-library/bashbrew/issues/51, https://github.com/docker-library/bashbrew/pull/61, https://github.com/docker-library/official-images/pull/13769 :eyes:)