### PR TITLE
Update to actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: Ensure no-TLS snapshot usage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Ensure http://snapshot.debian.org (https://github.com/debuerreotype/debuerreotype/pull/119#issuecomment-901457009)
         run: |
           rm .github/workflows/ci.yml # this file itself will always be a match, but it's the only valid one 👀
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-20.04
     env: ${{ matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Prepare Environment
         run: |
           sudo apt-get update -qq


### PR DESCRIPTION
(This should remove the Node.js deprecation warnings in our CI builds)