### PR TITLE
Copy /etc/skel/.bashrc to /root/.bashrc to fix bash-completion

### DIFF
--- a/scripts/debuerreotype-minimizing-config
+++ b/scripts/debuerreotype-minimizing-config
@@ -151,3 +151,8 @@ if [ -d "$targetDir/etc/apt/apt.conf.d" ]; then
 	chmod 0644 "$targetDir/etc/apt/apt.conf.d/docker-no-languages"
 	"$thisDir/.fix-apt-comments.sh" "$aptVersion" "$targetDir/etc/apt/apt.conf.d/docker-no-languages"
 fi
+
+# Check that /root/.bashrc has no non-comment lines and replace it to fix bash-completion. See https://bugs.debian.org/275623#63 . Hopefully this will also fix other bugs caused by user vs root mismatch
+if [ -f "$targetDir/root/.bashrc" ] && [ -f "$targetDir/etc/skel/.bashrc" ] && ! grep -qvE '^ *(#.*)?$' "$targetDir/root/.bashrc"; then
+	cp "$targetDir/etc/skel/.bashrc" "$targetDir/root/.bashrc"
+fi


### PR DESCRIPTION
Check that `/root/.bashrc` has no non-comment lines and replace it to fix bash-completion. See https://bugs.debian.org/275623#63 . Hopefully this will also fix other bugs caused by user vs root mismatch

---------

This patch fixes `cat --show-al<Tab>` or `apt-get ins<Tab>` behavior (in root non-login shell, which is default in docker). In other words, this patch enables bash-completion. It is not specific to `apt`. It is unrelated to https://github.com/debuerreotype/debuerreotype/pull/153 , which is specific to `apt` and fixes `apt-get install ap<Tab>` behavior assuming bash-completion is already enabled.

base-files developer rejected such approach in https://bugs.debian.org/275623 , so I have to send this to docker image generator. On real desktop system people rarely start root shell, but it is very common in docker. Yes, if someone wants bash-completion, he can simply do `cp /etc/skel/.bashrc /root/.bashrc` or just `bash -l`, but this is not discoverable