### PR TITLE
Add support to debian ports by passing --extra-suites flag

### DIFF
--- a/.validate-debian.sh
+++ b/.validate-debian.sh
@@ -19,6 +19,9 @@ if [ -n "${ARCH:-}" ]; then
 		fi
 	fi
 fi
+if [ -n "${EXTRASUITES:-}" ]; then
+	buildArgs+=( "--extra-suites=${EXTRASUITES}" )
+fi
 buildArgs+=( validate "$SUITE" "@$epoch" )
 
 checkFile="validate/$serial/${ARCH:-amd64}/${CODENAME:-$SUITE}/rootfs.tar.xz"

--- a/examples/debian.sh
+++ b/examples/debian.sh
@@ -9,7 +9,7 @@ source "$debuerreotypeScriptsDir/.constants.sh" \
 	--flags 'codename-copy' \
 	--flags 'eol,ports' \
 	--flags 'arch:' \
-	--flags 'include:,exclude:' \
+	--flags 'include:,exclude:,extra-suites:' \
 	-- \
 	'[--codename-copy] [--eol] [--ports] [--arch=<arch>] <output-dir> <suite> <timestamp>' \
 	'output stretch 2017-05-08T00:00:00Z
@@ -24,6 +24,7 @@ ports=
 include=
 exclude=
 arch=
+extraSuites=
 while true; do
 	flag="$1"; shift
 	dgetopt-case "$flag"
@@ -34,6 +35,7 @@ while true; do
 		--arch) arch="$1"; shift ;; # for adding "--arch" to debuerreotype-init
 		--include) include="${include:+$include,}$1"; shift ;;
 		--exclude) exclude="${exclude:+$exclude,}$1"; shift ;;
+		--extra-suites) extraSuites="$1"; shift ;; # for adding "--extra-suites" to debuerreotype-init
 		--) break ;;
 		*) eusage "unknown flag '$flag'" ;;
 	esac
@@ -107,6 +109,9 @@ if [ -n "$ports" ]; then
 		--debian-ports
 		--include=debian-ports-archive-keyring
 	)
+fi
+if [ -n "$extraSuites" ]; then
+	initArgs+=( --extra-suites "$extraSuites" )
 fi
 
 export GNUPGHOME="$tmpDir/gnupg"

--- a/scripts/debuerreotype-init
+++ b/scripts/debuerreotype-init
@@ -6,7 +6,7 @@ source "$thisDir/.constants.sh" \
 	--flags 'debian,debian-eol,debian-ports,non-debian' \
 	--flags 'debootstrap:' \
 	--flags 'debootstrap-script:' \
-	--flags 'keyring:,arch:,include:,exclude:' \
+	--flags 'keyring:,arch:,include:,exclude:,extra-suites:' \
 	--flags 'merged-usr,no-merged-usr' \
 	--flags 'check-gpg,no-check-gpg' \
 	-- \
@@ -27,6 +27,7 @@ keyring=
 arch=
 include=
 exclude=
+extraSuites=
 noMergedUsr=
 noCheckGpg=
 while true; do
@@ -43,6 +44,7 @@ while true; do
 		--arch) arch="$1"; shift ;;
 		--include) include="${include:+$include,}$1"; shift ;;
 		--exclude) exclude="${exclude:+$exclude,}$1"; shift ;;
+		--extra-suites) extraSuites="$1"; shift ;;
 		--merged-usr)    noMergedUsr=  ;;
 		--no-merged-usr) noMergedUsr=1 ;;
 		--check-gpg)    noCheckGpg=  ;;
@@ -126,6 +128,7 @@ fi
 [ -z "$arch" ] || debootstrapArgs+=( --arch="$arch" )
 [ -z "$include" ] || debootstrapArgs+=( --include="$include" )
 [ -z "$exclude" ] || debootstrapArgs+=( --exclude="$exclude" )
+[ -z "$extraSuites" ] || debootstrapArgs+=( --extra-suites="$extraSuites" )
 
 debootstrapArgs+=(
 	"$suite" "$targetDir" "$mirror" "$script"


### PR DESCRIPTION
This PR adds support to the debian-ports unreleased repositories for non main architectures.

The build.sh script can receive a `--extra-suites` parameter to use packages from the listed suites of the archive.

Ex. `ARCH=loong64 SUITE=unstable EXTRASUITES=unreleased CODENAME="" TIMESTAMP="today 00:00:00" ./.validate-debian.sh`

```sh
...
...
I: Unpacking util-linux-extra...
I: Unpacking util-linux...
W: Failure while unpacking required packages.  This will be attempted up to five times.
W: See /tmp/debuerreotype.unstable.Kxl58E0ImQ/rootfs/debootstrap/debootstrap.log for details (possibly the package /var/cache/apt/archives/usr-is-merged_35_all.deb is at fault)

error: 'unshare-debootstrap' failed!

  Full command:

    unshare-debootstrap --force-check-gpg --variant=minbase --merged-usr --keyring=/tmp/debuerreotype.unstable.Kxl58E0ImQ/debian-archive-unstable-keyring.gpg --arch=loong64 --extra-suites=unreleased --include=debian-ports-archive-keyring --extra-suites=unreleased unstable /tmp/debuerreotype.unstable.Kxl58E0ImQ/rootfs http://snapshot.debian.org/archive/debian-ports/20231204T000000Z /usr/share/debootstrap/scripts/sid

  Logs:


2023-12-04 22:40:40 URL:http://snapshot.debian.org/archive/debian-ports/20231204T000000Z/pool-loong64/main/u/util-linux/util-linux-extra_2.38.1-5+loong64_loong64.deb [107732/107732] -> "/tmp/debuerreotype.unstable.Kxl58E0ImQ/rootfs//var/cache/apt/archives/partial/util-linux-extra_2.38.1-5+loong64_loong64.deb" [1]
2023-12-04 22:40:45 URL:http://snapshot.debian.org/archive/debian-ports/20231204T000000Z/pool-loong64/main/u/util-linux/util-linux_2.38.1-5+loong64_loong64.deb [1108744/1108744] -> "/tmp/debuerreotype.unstable.Kxl58E0ImQ/rootfs//var/cache/apt/archives/partial/util-linux_2.38.1-5+loong64_loong64.deb" [1]
dpkg: warning: parsing file '/var/lib/dpkg/status' near line 5 package 'dpkg':
 missing 'Description' field
dpkg: warning: parsing file '/var/lib/dpkg/status' near line 5 package 'dpkg':
 missing 'Architecture' field
Selecting previously unselected package base-passwd.
(Reading database ... 0 files and directories currently installed.)
Preparing to unpack .../base-passwd_3.6.1+loong64_loong64.deb ...
Unpacking base-passwd (3.6.1+loong64) ...
dpkg: base-passwd: dependency problems, but configuring anyway as you requested:
 base-passwd depends on libc6 (>= 2.36); however:
  Package libc6 is not installed.
 base-passwd depends on libdebconfclient0 (>= 0.145); however:
  Package libdebconfclient0 is not installed.
 base-passwd depends on libselinux1 (>= 3.1~); however:
  Package libselinux1 is not installed.
...
...
Preparing to unpack .../tzdata_2023c-7_all.deb ...
Unpacking tzdata (2023c-7) ...
Selecting previously unselected package usr-is-merged.
Preparing to unpack .../usr-is-merged_35_all.deb ...


******************************************************************************
*
* The usr-is-merged package cannot be installed because this system does
* not have a merged /usr.
*
* Please install the usrmerge package to convert this system to merged-/usr.
*
* For more information please read https://wiki.debian.org/UsrMerge.
*
******************************************************************************


dpkg: error processing archive /var/cache/apt/archives/usr-is-merged_35_all.deb (--unpack):
 new usr-is-merged package pre-installation script subprocess returned error exit status 1
```

But using `trixie` can build successfully.

```sh
sed -i 's@FROM debian:bullseye-slim@FROM debian:trixie-slim@g' Dockerfile
ARCH=loong64 SUITE=unstable EXTRASUITES=unreleased CODENAME="" TIMESTAMP="today 00:00:00" ./.validate-debian.sh
```
This is the file generated after completion：[dist-loong64](https://github.com/wojiushixiaobai/docker-debian-artifacts/tree/dist-loong64)

<details>

<summary>Full log.</summary>

```sh
sed -i 's@FROM debian:bullseye-slim@FROM debian:trixie-slim@g' Dockerfile
ARCH=loong64 SUITE=unstable EXTRASUITES=unreleased CODENAME="" TIMESTAMP="today 00:00:00" ./.validate-debian.sh
```

```sh
root@debian:/opt/github.com/debuerreotype/debuerreotype# ARCH=loong64 SUITE=unstable EXTRASUITES=unreleased CODENAME="" TIMESTAMP="today 00:00:00" ./.validate-debian.sh
+ ./scripts/debuerreotype-version
0.16-dev commit 60b625d
+ ./docker-run.sh --pull ./examples/debian.sh --arch=loong64 --ports --extra-suites=unreleased validate unstable @1701648000
[+] Building 0.9s (13/13) FINISHED                                                                                                                                              docker:default
 => [internal] load .dockerignore                                                                                                                                                         0.0s
 => => transferring context: 74B                                                                                                                                                          0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                      0.0s
 => => transferring dockerfile: 5.14kB                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/library/debian:trixie-slim                                                                                                                     0.9s
 => [1/8] FROM docker.io/library/debian:trixie-slim@sha256:66031ed6e07b356435e20c700a98fd5f5d0cf97a1a10ab21d30121f68cc9d747                                                               0.0s
 => [internal] load build context                                                                                                                                                         0.0s
 => => transferring context: 1.51kB                                                                                                                                                       0.0s
 => CACHED [2/8] RUN set -eux;  apt-get update;  apt-get install -y --no-install-recommends   debian-ports-archive-keyring   debootstrap   wget ca-certificates   xz-utils     gnupg dir  0.0s
 => CACHED [3/8] RUN echo 'hsts=0' >> "/.wgetrc"                                                                                                                                          0.0s
 => CACHED [4/8] RUN set -eux;  wget -O distro-info-data.deb 'http://snapshot.debian.org/archive/debian/20230429T210410Z/pool/main/d/distro-info-data/distro-info-data_0.58_all.deb';  e  0.0s
 => CACHED [5/8] RUN set -eux;  apt-get update;  apt-get install -y --no-install-recommends patch;  rm -rf /var/lib/apt/lists/*;   wget -O debootstrap-download-main.patch 'https://peop  0.0s
 => CACHED [6/8] COPY . /opt/debuerreotype                                                                                                                                                0.0s
 => CACHED [7/8] RUN set -eux;  cd /opt/debuerreotype/scripts;  for f in debuerreotype-*; do   ln -svL "$PWD/$f" "/usr/local/bin/$f";  done;  version="$(debuerreotype-version)";  [ "$v  0.0s
 => CACHED [8/8] WORKDIR /tmp                                                                                                                                                             0.0s
 => exporting to image                                                                                                                                                                    0.0s
 => => exporting layers                                                                                                                                                                   0.0s
 => => writing image sha256:bda90fdaf31f8274d91e80ed5453c6f6e1e983e48b9aefb8e31eaf248f5eae93                                                                                              0.0s
 => => naming to docker.io/debuerreotype/debuerreotype:0.16-dev                                                                                                                           0.0s
++ readlink -ve validate
+ outputDir=/workdir/validate
++ mktemp --directory --tmpdir debuerreotype.unstable.XXXXXXXXXX
+ tmpDir=/tmp/debuerreotype.unstable.eKhW1q2jnx
++ printf 'rm -rf %q' /tmp/debuerreotype.unstable.eKhW1q2jnx
+ trap 'rm -rf /tmp/debuerreotype.unstable.eKhW1q2jnx' EXIT
+ export TZ=UTC LC_ALL=C
+ TZ=UTC
+ LC_ALL=C
++ date --date @1701648000 +%s
+ epoch=1701648000
++ date --date @1701648000 +%Y%m%d
+ serial=20231204
+ dpkgArch=loong64
+ exportDir=/tmp/debuerreotype.unstable.eKhW1q2jnx/output
+ archDir=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64
+ tmpOutputDir=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable
+ for archive in '' security
+ snapshotUrlFile=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/snapshot-url
+ mirrorArgs=()
+ '[' -n 1 ']'
+ mirrorArgs+=(--ports)
+ '[' -n '' ']'
+ mirrorArgs+=("@$epoch" "$suite${archive:+-$archive}" "$dpkgArch" main)
++ /opt/debuerreotype/scripts/.debian-mirror.sh --ports @1701648000 unstable loong64 main
+ mirrors='mirror=http://deb.debian.org/debian-ports
snapshotMirror=http://snapshot.debian.org/archive/debian-ports/20231204T000000Z
foundSuite=unstable'
+ eval 'mirror=http://deb.debian.org/debian-ports
snapshotMirror=http://snapshot.debian.org/archive/debian-ports/20231204T000000Z
foundSuite=unstable'
++ mirror=http://deb.debian.org/debian-ports
++ snapshotMirror=http://snapshot.debian.org/archive/debian-ports/20231204T000000Z
++ foundSuite=unstable
+ '[' -n http://snapshot.debian.org/archive/debian-ports/20231204T000000Z ']'
++ dirname /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/snapshot-url
+ snapshotUrlDir=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64
+ mkdir -p /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64
+ echo http://snapshot.debian.org/archive/debian-ports/20231204T000000Z
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/snapshot-url
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/snapshot-url
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/snapshot-url
+ '[' 0 -gt 0 ']'
+ for archive in '' security
+ snapshotUrlFile=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/snapshot-url-security
+ mirrorArgs=()
+ '[' -n 1 ']'
+ mirrorArgs+=(--ports)
+ '[' -n '' ']'
+ mirrorArgs+=("@$epoch" "$suite${archive:+-$archive}" "$dpkgArch" main)
++ /opt/debuerreotype/scripts/.debian-mirror.sh --ports @1701648000 unstable-security loong64 main
warning: no apparent 'unstable-security/main' for 'loong64' on any of the following
  - http://snapshot.debian.org/archive/debian-security/20231204T000000Z
+ mirrors=
+ '[' security = security ']'
+ continue
+ initArgs=(--arch "$dpkgArch")
+ '[' -z '' ']'
+ initArgs+=(--debian)
+ '[' -n 1 ']'
+ initArgs+=(--debian-ports --include=debian-ports-archive-keyring)
+ '[' -n unreleased ']'
+ initArgs+=(--extra-suites "$extraSuites")
+ export GNUPGHOME=/tmp/debuerreotype.unstable.eKhW1q2jnx/gnupg
+ GNUPGHOME=/tmp/debuerreotype.unstable.eKhW1q2jnx/gnupg
+ mkdir -p /tmp/debuerreotype.unstable.eKhW1q2jnx/gnupg
+ keyring=/tmp/debuerreotype.unstable.eKhW1q2jnx/debian-archive-unstable-keyring.gpg
+ '[' unstable = slink ']'
+ '[' unstable = potato ']'
+ gpg --batch --no-default-keyring --keyring /tmp/debuerreotype.unstable.eKhW1q2jnx/debian-archive-unstable-keyring.gpg --import /usr/share/keyrings/debian-archive-keyring.gpg /usr/share/keyrings/debian-archive-removed-keys.gpg
gpg: WARNING: unsafe permissions on homedir '/tmp/debuerreotype.unstable.eKhW1q2jnx/gnupg'
gpg: keybox '/tmp/debuerreotype.unstable.eKhW1q2jnx/debian-archive-unstable-keyring.gpg' created
gpg: key DCC9EFBF77E11517: 2 signatures not checked due to missing keys
gpg: /tmp/debuerreotype.unstable.eKhW1q2jnx/gnupg/trustdb.gpg: trustdb created
gpg: key DCC9EFBF77E11517: public key "Debian Stable Release Key (10/buster) <debian-release@lists.debian.org>" imported
gpg: key DC30D7C23CBBABEE: 4 signatures not checked due to missing keys
gpg: key DC30D7C23CBBABEE: public key "Debian Archive Automatic Signing Key (10/buster) <ftpmaster@debian.org>" imported
gpg: key 4DFAB270CAA96DFA: 4 signatures not checked due to missing keys
gpg: key 4DFAB270CAA96DFA: public key "Debian Security Archive Automatic Signing Key (10/buster) <ftpmaster@debian.org>" imported
gpg: key 73A4F27B8DD47936: 3 signatures not checked due to missing keys
gpg: key 73A4F27B8DD47936: public key "Debian Archive Automatic Signing Key (11/bullseye) <ftpmaster@debian.org>" imported
gpg: key A48449044AAD5C5D: 2 signatures not checked due to missing keys
gpg: key A48449044AAD5C5D: public key "Debian Security Archive Automatic Signing Key (11/bullseye) <ftpmaster@debian.org>" imported
gpg: key 605C66F00D6C9793: 3 signatures not checked due to missing keys
gpg: key 605C66F00D6C9793: public key "Debian Stable Release Key (11/bullseye) <debian-release@lists.debian.org>" imported
gpg: key F8D2585B8783D481: public key "Debian Stable Release Key (12/bookworm) <debian-release@lists.debian.org>" imported
gpg: key B7C5D7D6350947F8: 3 signatures not checked due to missing keys
gpg: key B7C5D7D6350947F8: public key "Debian Archive Automatic Signing Key (12/bookworm) <ftpmaster@debian.org>" imported
gpg: key 254CF3B5AEC0A8F0: 2 signatures not checked due to missing keys
gpg: key 254CF3B5AEC0A8F0: public key "Debian Security Archive Automatic Signing Key (12/bookworm) <ftpmaster@debian.org>" imported
gpg: key 6FFA8EF91DB114E0: 1 signature not checked due to a missing key
gpg: key 6FFA8EF91DB114E0: public key "Debian Archive Automatic Signing Key (2004) <ftpmaster@debian.org>" imported
gpg: Note: signatures using the MD5 algorithm are rejected
gpg: key F1D53D8C4F368D5D: 1 signature not checked due to a missing key
gpg: key F1D53D8C4F368D5D: 1 bad signature
gpg: key F1D53D8C4F368D5D: public key "Debian Archive Automatic Signing Key (2005) <ftpmaster@debian.org>" imported
gpg: key E415B2B4B5F5BBED: 3 signatures not checked due to missing keys
gpg: key E415B2B4B5F5BBED: public key "Debian AMD64 Archive Key <debian-amd64@lists.debian.org>" imported
gpg: key 010908312D230C5F: 12 signatures not checked due to missing keys
gpg: key 010908312D230C5F: public key "Debian Archive Automatic Signing Key (2006) <ftpmaster@debian.org>" imported
gpg: key A70DAF536070D3A1: 1 signature not checked due to a missing key
gpg: key A70DAF536070D3A1: public key "Debian Archive Automatic Signing Key (4.0/etch) <ftpmaster@debian.org>" imported
gpg: key B5D0C804ADB11277: 2 signatures not checked due to missing keys
gpg: key B5D0C804ADB11277: public key "Etch Stable Release Key <debian-release@lists.debian.org>" imported
gpg: key EC61E0B0BBE55AB3: 1 signature not checked due to a missing key
gpg: key EC61E0B0BBE55AB3: public key "Debian-Volatile Archive Automatic Signing Key (4.0/etch)" imported
gpg: key 9AA38DCD55BE302B: 3 signatures not checked due to missing keys
gpg: key 9AA38DCD55BE302B: public key "Debian Archive Automatic Signing Key (5.0/lenny) <ftpmaster@debian.org>" imported
gpg: key 4D270D06F42584E6: 5 signatures not checked due to missing keys
gpg: key 4D270D06F42584E6: public key "Lenny Stable Release Key <debian-release@lists.debian.org>" imported
gpg: key DFD993306D849617: 1 signature not checked due to a missing key
gpg: key DFD993306D849617: public key "Debian-Volatile Archive Automatic Signing Key (5.0/lenny)" imported
gpg: key 64481591B98321F9: 3 signatures not checked due to missing keys
gpg: key 64481591B98321F9: public key "Squeeze Stable Release Key <debian-release@lists.debian.org>" imported
gpg: key AED4B06F473041FA: 10 signatures not checked due to missing keys
gpg: key AED4B06F473041FA: public key "Debian Archive Automatic Signing Key (6.0/squeeze) <ftpmaster@debian.org>" imported
gpg: key 8B48AD6246925553: 6 signatures not checked due to missing keys
gpg: key 8B48AD6246925553: public key "Debian Archive Automatic Signing Key (7.0/wheezy) <ftpmaster@debian.org>" imported
gpg: key 6FB2A1C265FFB764: 3 signatures not checked due to missing keys
gpg: key 6FB2A1C265FFB764: public key "Wheezy Stable Release Key <debian-release@lists.debian.org>" imported
gpg: key CBF8D6FD518E17E1: 2 signatures not checked due to missing keys
gpg: key CBF8D6FD518E17E1: public key "Jessie Stable Release Key <debian-release@lists.debian.org>" imported
gpg: key 7638D0442B90D010: 3 signatures not checked due to missing keys
gpg: key 7638D0442B90D010: public key "Debian Archive Automatic Signing Key (8/jessie) <ftpmaster@debian.org>" imported
gpg: key 9D6D8F6BC857C906: 3 signatures not checked due to missing keys
gpg: key 9D6D8F6BC857C906: public key "Debian Security Archive Automatic Signing Key (8/jessie) <ftpmaster@debian.org>" imported
gpg: key EF0F382A1A7B6500: 2 signatures not checked due to missing keys
gpg: key EF0F382A1A7B6500: public key "Debian Stable Release Key (9/stretch) <debian-release@lists.debian.org>" imported
gpg: key E0B11894F66AEC98: 3 signatures not checked due to missing keys
gpg: key E0B11894F66AEC98: public key "Debian Archive Automatic Signing Key (9/stretch) <ftpmaster@debian.org>" imported
gpg: key EDA0D2388AE22BA9: 3 signatures not checked due to missing keys
gpg: key EDA0D2388AE22BA9: public key "Debian Security Archive Automatic Signing Key (9/stretch) <ftpmaster@debian.org>" imported
gpg: Total number processed: 29
gpg:               imported: 29
gpg: no ultimately trusted keys found
+ '[' -n 1 ']'
+ gpg --batch --no-default-keyring --keyring /tmp/debuerreotype.unstable.eKhW1q2jnx/debian-archive-unstable-keyring.gpg --import /usr/share/keyrings/debian-ports-archive-keyring.gpg /usr/share/keyrings/debian-ports-archive-keyring-removed.gpg
gpg: WARNING: unsafe permissions on homedir '/tmp/debuerreotype.unstable.eKhW1q2jnx/gnupg'
gpg: key B523E5F3FC4E5F2C: public key "Debian Ports Archive Automatic Signing Key (2023) <ftpmaster@ports-master.debian.org>" imported
gpg: key 8D69674688B6CB36: public key "Debian Ports Archive Automatic Signing Key (2024) <ftpmaster@ports-master.debian.org>" imported
gpg: key 3A3B88433E4C6047: 1 signature not checked due to a missing key
gpg: key 3A3B88433E4C6047: public key "Debian Ports Archive Automatic Signing Key (2007) <ftpmaster@debian-ports.org>" imported
gpg: key 0792182443229C06: 1 signature not checked due to a missing key
gpg: key 0792182443229C06: public key "Debian Ports Archive Automatic Signing Key (2008) <ftpmaster@debian-ports.org>" imported
gpg: key AE4A31290917E535: 1 signature not checked due to a missing key
gpg: key AE4A31290917E535: public key "Debian Ports Archive Automatic Signing Key (2009) <ftpmaster@debian-ports.org>" imported
gpg: key F460A91E4D922A56: 2 signatures not checked due to missing keys
gpg: key F460A91E4D922A56: public key "Debian Ports Archive Automatic Signing Key (2010) <ftpmaster@debian-ports.org>" imported
gpg: key D9B937C622261D71: 2 signatures not checked due to missing keys
gpg: key D9B937C622261D71: public key "Debian Ports Archive Automatic Signing Key (2011) <ftpmaster@debian-ports.org>" imported
gpg: key A2A560BCA92F9FF4: 2 signatures not checked due to missing keys
gpg: key A2A560BCA92F9FF4: public key "Debian Ports Archive Automatic Signing Key (2012) <ftpmaster@debian-ports.org>" imported
gpg: key 1C466F272FF7A9F4: 2 signatures not checked due to missing keys
gpg: key 1C466F272FF7A9F4: public key "Debian Ports Archive Automatic Signing Key (2013) <ftpmaster@debian-ports.org>" imported
gpg: key AA651E74623DB0B8: 2 signatures not checked due to missing keys
gpg: key AA651E74623DB0B8: public key "Debian Ports Archive Automatic Signing Key (2014) <ftpmaster@debian-ports.org>" imported
gpg: key A53AB45AC448326E: 1 signature not checked due to a missing key
gpg: key A53AB45AC448326E: public key "Debian Ports Archive Automatic Signing Key (2015) <ftpmaster@debian-ports.org>" imported
gpg: key B4C86482705A2CE1: 1 signature not checked due to a missing key
gpg: key B4C86482705A2CE1: public key "Debian Ports Archive Automatic Signing Key (2016) <ftpmaster@debian-ports.org>" imported
gpg: key 8BC3A7D46F930576: 1 signature not checked due to a missing key
gpg: key 8BC3A7D46F930576: public key "Debian Ports Archive Automatic Signing Key (2017) <ftpmaster@ports-master.debian.org>" imported
gpg: key 06AED62430CB581C: public key "Debian Ports Archive Automatic Signing Key (2018) <ftpmaster@ports-master.debian.org>" imported
gpg: key DA1B2CEA81DCBC61: public key "Debian Ports Archive Automatic Signing Key (2019) <ftpmaster@ports-master.debian.org>" imported
gpg: key 84C573CD4E1AFD6C: public key "Debian Ports Archive Automatic Signing Key (2020) <ftpmaster@ports-master.debian.org>" imported
gpg: key 5A88D659DCB811BB: public key "Debian Ports Archive Automatic Signing Key (2021) <ftpmaster@ports-master.debian.org>" imported
gpg: key E852514F5DF312F6: public key "Debian Ports Archive Automatic Signing Key (2022) <ftpmaster@ports-master.debian.org>" imported
gpg: Total number processed: 18
gpg:               imported: 18
gpg: no ultimately trusted keys found
+ initArgs+=(--keyring "$keyring")
+ mkdir -p /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable
+ mirror=http://snapshot.debian.org/archive/debian-ports/20231204T000000Z
+ '[' -f /tmp/debuerreotype.unstable.eKhW1q2jnx/debian-archive-unstable-keyring.gpg ']'
+ wget -O /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/InRelease http://snapshot.debian.org/archive/debian-ports/20231204T000000Z/dists/unstable/InRelease
--2023-12-04 23:09:13--  http://snapshot.debian.org/archive/debian-ports/20231204T000000Z/dists/unstable/InRelease
Resolving snapshot.debian.org (snapshot.debian.org)... 193.62.202.27, 185.17.185.185, 2001:1af8:4020:b030:deb::185, ...
Connecting to snapshot.debian.org (snapshot.debian.org)|193.62.202.27|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 93584 (91K)
Saving to: '/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/InRelease'

/tmp/debuerreotype.unstable.eKhW1q2jnx/output/2 100%[======================================================================================================>]  91.39K  80.2KB/s    in 1.1s    

2023-12-04 23:09:15 (80.2 KB/s) - '/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/InRelease' saved [93584/93584]

+ gpgv --status-fd 3 --keyring /tmp/debuerreotype.unstable.eKhW1q2jnx/debian-archive-unstable-keyring.gpg --output /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/Release /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/InRelease
gpgv: can't allocate lock for '/tmp/debuerreotype.unstable.eKhW1q2jnx/debian-archive-unstable-keyring.gpg'
gpgv: Signature made Mon Jul 24 13:23:50 2023 UTC
gpgv:                using RSA key D0C987D7BEC3EDDF89486CC2B523E5F3FC4E5F2C
gpgv: Good signature from "Debian Ports Archive Automatic Signing Key (2023) <ftpmaster@ports-master.debian.org>"
gpgv: Signature made Mon Jul 24 13:23:50 2023 UTC
gpgv:                using RSA key 01C2D6F3D1A46AD1C0DC2F3D8D69674688B6CB36
gpgv: Good signature from "Debian Ports Archive Automatic Signing Key (2024) <ftpmaster@ports-master.debian.org>"
+ '[' -s /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/Release ']'
+ codename=
+ '[' -f /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/Release ']'
++ awk -F ': ' '$1 == "Codename" { print $2; exit }' /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/Release
+ codename=sid
+ '[' -n '' ']'
+ '[' -n '' ']'
+ case "${codename:-$suite}" in
++ date --date '2022-07-24 00:00:00' +%s
+ epochUsrIsMerged=1658620800
+ '[' 1701648000 -lt 1658620800 ']'
+ initArgs+=(--merged-usr)
++ command -v debootstrap
+ debootstrap=/usr/sbin/debootstrap
+ grep -q EXCLUDE_DEPENDENCY /usr/sbin/debootstrap
+ grep -q EXCLUDE_DEPENDENCY /usr/share/debootstrap/functions
+ '[' -n '' ']'
+ '[' -n '' ']'
+ rootfsDir=/tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs
+ debuerreotype-init --arch loong64 --debian --debian-ports --include=debian-ports-archive-keyring --extra-suites unreleased --keyring /tmp/debuerreotype.unstable.eKhW1q2jnx/debian-archive-unstable-keyring.gpg --merged-usr /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs unstable @1701648000
I: Retrieving InRelease 
I: Checking Release signature
I: Valid Release signature (key id 01C2D6F3D1A46AD1C0DC2F3D8D69674688B6CB36)
I: Retrieving Packages 
I: Validating Packages 
I: Retrieving InRelease 
I: Checking Release signature
I: Valid Release signature (key id 01C2D6F3D1A46AD1C0DC2F3D8D69674688B6CB36)
I: Retrieving Packages 
I: Validating Packages 
I: Resolving dependencies of required packages...
I: Resolving dependencies of base packages...
I: Checking component main on http://snapshot.debian.org/archive/debian-ports/20231204T000000Z...
I: Checking component main on http://snapshot.debian.org/archive/debian-ports/20231204T000000Z...
I: Retrieving adduser 3.137
I: Validating adduser 3.137
I: Retrieving apt 2.6.1
I: Validating apt 2.6.1
I: Retrieving base-files 12.4
I: Validating base-files 12.4
I: Retrieving coreutils 9.1-1
I: Validating coreutils 9.1-1
I: Retrieving dash 0.5.12-2
I: Validating dash 0.5.12-2
I: Retrieving debconf 1.5.82
I: Validating debconf 1.5.82
I: Retrieving debian-archive-keyring 2023.3
I: Validating debian-archive-keyring 2023.3
I: Retrieving debian-ports-archive-keyring 2023.02.01
I: Validating debian-ports-archive-keyring 2023.02.01
I: Retrieving debianutils 5.7-0.4
I: Validating debianutils 5.7-0.4
I: Retrieving diffutils 1:3.8-4
I: Validating diffutils 1:3.8-4
I: Retrieving dpkg 1.21.22
I: Validating dpkg 1.21.22
I: Retrieving e2fsprogs 1.47.0-2
I: Validating e2fsprogs 1.47.0-2
I: Retrieving findutils 4.9.0-4
I: Validating findutils 4.9.0-4
I: Retrieving grep 3.8-5
I: Validating grep 3.8-5
I: Retrieving gzip 1.12-1
I: Validating gzip 1.12-1
I: Retrieving hostname 3.23+nmu1
I: Validating hostname 3.23+nmu1
I: Retrieving init-system-helpers 1.65.2
I: Validating init-system-helpers 1.65.2
I: Retrieving libacl1 2.3.1-3
I: Validating libacl1 2.3.1-3
I: Retrieving libapt-pkg6.0 2.6.1
I: Validating libapt-pkg6.0 2.6.1
I: Retrieving libattr1 1:2.5.1-4
I: Validating libattr1 1:2.5.1-4
I: Retrieving libaudit-common 1:3.1.1-1
I: Validating libaudit-common 1:3.1.1-1
I: Retrieving libaudit1 1:3.0.9-1
I: Validating libaudit1 1:3.0.9-1
I: Retrieving libbrotli1 1.0.9-2
I: Validating libbrotli1 1.0.9-2
I: Retrieving libbz2-1.0 1.0.8-5
I: Validating libbz2-1.0 1.0.8-5
I: Retrieving libcap-ng0 0.8.3-1
I: Validating libcap-ng0 0.8.3-1
I: Retrieving libcap2 1:2.66-4
I: Validating libcap2 1:2.66-4
I: Retrieving libcom-err2 1.47.0-2
I: Validating libcom-err2 1.47.0-2
I: Retrieving libcrypt1 1:4.4.33-2
I: Validating libcrypt1 1:4.4.33-2
I: Retrieving libext2fs2 1.47.0-2
I: Validating libext2fs2 1.47.0-2
I: Retrieving libffi8 3.4.4-1
I: Validating libffi8 3.4.4-1
I: Retrieving libgmp10 2:6.2.1+dfsg1-1.1
I: Validating libgmp10 2:6.2.1+dfsg1-1.1
I: Retrieving libhogweed6 3.8.1-2
I: Validating libhogweed6 3.8.1-2
I: Retrieving liblz4-1 1.9.4-1
I: Validating liblz4-1 1.9.4-1
I: Retrieving liblzma5 5.4.1-0.2
I: Validating liblzma5 5.4.1-0.2
I: Retrieving libmd0 1.0.4-2
I: Validating libmd0 1.0.4-2
I: Retrieving libnettle8 3.8.1-2
I: Validating libnettle8 3.8.1-2
I: Retrieving libpam-modules 1.5.2-6
I: Validating libpam-modules 1.5.2-6
I: Retrieving libpam-modules-bin 1.5.2-6
I: Validating libpam-modules-bin 1.5.2-6
I: Retrieving libpam-runtime 1.5.2-6
I: Validating libpam-runtime 1.5.2-6
I: Retrieving libpam0g 1.5.2-6
I: Validating libpam0g 1.5.2-6
I: Retrieving libpcre2-8-0 10.42-1
I: Validating libpcre2-8-0 10.42-1
I: Retrieving libsemanage-common 3.5-1
I: Validating libsemanage-common 3.5-1
I: Retrieving libsepol2 3.4-2.1
I: Validating libsepol2 3.4-2.1
I: Retrieving libss2 1.47.0-2
I: Validating libss2 1.47.0-2
I: Retrieving libssl3 3.0.9-1
I: Validating libssl3 3.0.9-1
I: Retrieving libtasn1-6 4.19.0-2
I: Validating libtasn1-6 4.19.0-2
I: Retrieving libtinfo6 6.4-4
I: Validating libtinfo6 6.4-4
I: Retrieving libunistring2 1.0-2
I: Validating libunistring2 1.0-2
I: Retrieving libxxhash0 0.8.1-1
I: Validating libxxhash0 0.8.1-1
I: Retrieving libzstd1 1.5.4+dfsg2-5
I: Validating libzstd1 1.5.4+dfsg2-5
I: Retrieving login 1:4.13+dfsg1-1
I: Validating login 1:4.13+dfsg1-1
I: Retrieving logsave 1.47.0-2
I: Validating logsave 1.47.0-2
I: Retrieving mawk 1.3.4.20200120-3.1
I: Validating mawk 1.3.4.20200120-3.1
I: Retrieving ncurses-base 6.4-4
I: Validating ncurses-base 6.4-4
I: Retrieving ncurses-bin 6.4-4
I: Validating ncurses-bin 6.4-4
I: Retrieving passwd 1:4.13+dfsg1-1
I: Validating passwd 1:4.13+dfsg1-1
I: Retrieving perl-base 5.36.0-7
I: Validating perl-base 5.36.0-7
I: Retrieving tar 1.34+dfsg-1.2
I: Validating tar 1.34+dfsg-1.2
I: Retrieving tzdata 2023c-7
I: Validating tzdata 2023c-7
I: Retrieving usr-is-merged 35
I: Validating usr-is-merged 35
I: Retrieving zlib1g 1:1.2.13.dfsg-1
I: Validating zlib1g 1:1.2.13.dfsg-1
I: Retrieving base-passwd 3.6.1+loong64
I: Validating base-passwd 3.6.1+loong64
I: Retrieving bash 5.2.15-2+loong64
I: Validating bash 5.2.15-2+loong64
I: Retrieving bsdutils 1:2.38.1-5+loong64
I: Validating bsdutils 1:2.38.1-5+loong64
I: Retrieving gcc-12-base 12.2.0-14+loong64
I: Validating gcc-12-base 12.2.0-14+loong64
I: Retrieving gpgv 2.2.40-1.1+loong64
I: Validating gpgv 2.2.40-1.1+loong64
I: Retrieving libblkid1 2.38.1-5+loong64
I: Validating libblkid1 2.38.1-5+loong64
I: Retrieving libc-bin 2.36-9+loong64
I: Validating libc-bin 2.36-9+loong64
I: Retrieving libc6 2.36-9+loong64
I: Validating libc6 2.36-9+loong64
I: Retrieving libdb5.3 5.3.28+dfsg2-1+loong64
I: Validating libdb5.3 5.3.28+dfsg2-1+loong64
I: Retrieving libdebconfclient0 0.270+loong64
I: Validating libdebconfclient0 0.270+loong64
I: Retrieving libgcc-s1 12.2.0-14+loong64
I: Validating libgcc-s1 12.2.0-14+loong64
I: Retrieving libgcrypt20 1.10.2-2+loong64
I: Validating libgcrypt20 1.10.2-2+loong64
I: Retrieving libgnutls30 3.7.9-2+loong64
I: Validating libgnutls30 3.7.9-2+loong64
I: Retrieving libgpg-error0 1.46-1+loong64
I: Validating libgpg-error0 1.46-1+loong64
I: Retrieving libidn2-0 2.3.3-1+loong64
I: Validating libidn2-0 2.3.3-1+loong64
I: Retrieving libmount1 2.38.1-5+loong64
I: Validating libmount1 2.38.1-5+loong64
I: Retrieving libp11-kit0 0.24.1-2+loong64
I: Validating libp11-kit0 0.24.1-2+loong64
I: Retrieving libseccomp2 2.5.4-1+loong64
I: Validating libseccomp2 2.5.4-1+loong64
I: Retrieving libselinux1 3.4-1+loong64
I: Validating libselinux1 3.4-1+loong64
I: Retrieving libsemanage2 3.4-1+loong64
I: Validating libsemanage2 3.4-1+loong64
I: Retrieving libsmartcols1 2.38.1-5+loong64
I: Validating libsmartcols1 2.38.1-5+loong64
I: Retrieving libstdc++6 12.2.0-14+loong64
I: Validating libstdc++6 12.2.0-14+loong64
I: Retrieving libsystemd0 252.6-1+loong64
I: Validating libsystemd0 252.6-1+loong64
I: Retrieving libudev1 252.6-1+loong64
I: Validating libudev1 252.6-1+loong64
I: Retrieving libuuid1 2.38.1-5+loong64
I: Validating libuuid1 2.38.1-5+loong64
I: Retrieving mount 2.38.1-5+loong64
I: Validating mount 2.38.1-5+loong64
I: Retrieving sed 4.9-1+loong64
I: Validating sed 4.9-1+loong64
I: Retrieving sysvinit-utils 3.07-1+loong64
I: Validating sysvinit-utils 3.07-1+loong64
I: Retrieving util-linux 2.38.1-5+loong64
I: Validating util-linux 2.38.1-5+loong64
I: Retrieving util-linux-extra 2.38.1-5+loong64
I: Validating util-linux-extra 2.38.1-5+loong64
I: Chosen extractor for .deb packages: dpkg-deb
I: Extracting adduser...
I: Extracting apt...
I: Extracting base-files...
I: Extracting coreutils...
I: Extracting dash...
I: Extracting debconf...
I: Extracting debian-archive-keyring...
I: Extracting debianutils...
I: Extracting diffutils...
I: Extracting dpkg...
I: Extracting e2fsprogs...
I: Extracting findutils...
I: Extracting grep...
I: Extracting gzip...
I: Extracting hostname...
I: Extracting init-system-helpers...
I: Extracting libacl1...
I: Extracting libapt-pkg6.0...
I: Extracting libattr1...
I: Extracting libaudit-common...
I: Extracting libaudit1...
I: Extracting libbrotli1...
I: Extracting libbz2-1.0...
I: Extracting libcap-ng0...
I: Extracting libcap2...
I: Extracting libcom-err2...
I: Extracting libcrypt1...
I: Extracting libext2fs2...
I: Extracting libffi8...
I: Extracting libgmp10...
I: Extracting libhogweed6...
I: Extracting liblz4-1...
I: Extracting liblzma5...
I: Extracting libmd0...
I: Extracting libnettle8...
I: Extracting libpam-modules...
I: Extracting libpam-modules-bin...
I: Extracting libpam-runtime...
I: Extracting libpam0g...
I: Extracting libpcre2-8-0...
I: Extracting libsemanage-common...
I: Extracting libsepol2...
I: Extracting libss2...
I: Extracting libssl3...
I: Extracting libtasn1-6...
I: Extracting libtinfo6...
I: Extracting libunistring2...
I: Extracting libxxhash0...
I: Extracting libzstd1...
I: Extracting login...
I: Extracting logsave...
I: Extracting mawk...
I: Extracting ncurses-base...
I: Extracting ncurses-bin...
I: Extracting passwd...
I: Extracting perl-base...
I: Extracting tar...
I: Extracting tzdata...
I: Extracting usr-is-merged...
I: Extracting zlib1g...
I: Extracting base-passwd...
I: Extracting bash...
I: Extracting bsdutils...
I: Extracting gcc-12-base...
I: Extracting gpgv...
I: Extracting libblkid1...
I: Extracting libc-bin...
I: Extracting libc6...
I: Extracting libdb5.3...
I: Extracting libdebconfclient0...
I: Extracting libgcc-s1...
I: Extracting libgcrypt20...
I: Extracting libgnutls30...
I: Extracting libgpg-error0...
I: Extracting libidn2-0...
I: Extracting libmount1...
I: Extracting libp11-kit0...
I: Extracting libseccomp2...
I: Extracting libselinux1...
I: Extracting libsemanage2...
I: Extracting libsmartcols1...
I: Extracting libstdc++6...
I: Extracting libsystemd0...
I: Extracting libudev1...
I: Extracting libuuid1...
I: Extracting mount...
I: Extracting sed...
I: Extracting sysvinit-utils...
I: Extracting util-linux...
I: Extracting util-linux-extra...
I: Installing core packages...
I: Unpacking required packages...
I: Unpacking adduser...
I: Unpacking apt...
I: Unpacking base-files...
I: Unpacking coreutils...
I: Unpacking dash...
I: Unpacking debconf...
I: Unpacking debian-archive-keyring...
I: Unpacking debianutils...
I: Unpacking diffutils...
I: Unpacking dpkg...
I: Unpacking e2fsprogs...
I: Unpacking findutils...
I: Unpacking grep...
I: Unpacking gzip...
I: Unpacking hostname...
I: Unpacking init-system-helpers...
I: Unpacking libacl1:loong64...
I: Unpacking libapt-pkg6.0:loong64...
I: Unpacking libattr1:loong64...
I: Unpacking libaudit-common...
I: Unpacking libaudit1:loong64...
I: Unpacking libbrotli1:loong64...
I: Unpacking libbz2-1.0:loong64...
I: Unpacking libcap-ng0:loong64...
I: Unpacking libcap2:loong64...
I: Unpacking libcom-err2:loong64...
I: Unpacking libcrypt1:loong64...
I: Unpacking libext2fs2:loong64...
I: Unpacking libffi8:loong64...
I: Unpacking libgmp10:loong64...
I: Unpacking libhogweed6:loong64...
I: Unpacking liblz4-1:loong64...
I: Unpacking liblzma5:loong64...
I: Unpacking libmd0:loong64...
I: Unpacking libnettle8:loong64...
I: Unpacking libpam-modules:loong64...
I: Unpacking libpam-modules-bin...
I: Unpacking libpam-runtime...
I: Unpacking libpam0g:loong64...
I: Unpacking libpcre2-8-0:loong64...
I: Unpacking libsemanage-common...
I: Unpacking libsepol2:loong64...
I: Unpacking libss2:loong64...
I: Unpacking libssl3:loong64...
I: Unpacking libtasn1-6:loong64...
I: Unpacking libtinfo6:loong64...
I: Unpacking libunistring2:loong64...
I: Unpacking libxxhash0:loong64...
I: Unpacking libzstd1:loong64...
I: Unpacking login...
I: Unpacking logsave...
I: Unpacking mawk...
I: Unpacking ncurses-base...
I: Unpacking ncurses-bin...
I: Unpacking passwd...
I: Unpacking perl-base...
I: Unpacking tar...
I: Unpacking tzdata...
I: Unpacking usr-is-merged...
I: Unpacking zlib1g:loong64...
I: Unpacking base-passwd...
I: Unpacking bash...
I: Unpacking bsdutils...
I: Unpacking gcc-12-base:loong64...
I: Unpacking gpgv...
I: Unpacking libblkid1:loong64...
I: Unpacking libc-bin...
I: Unpacking libc6:loong64...
I: Unpacking libdb5.3:loong64...
I: Unpacking libdebconfclient0:loong64...
I: Unpacking libgcc-s1:loong64...
I: Unpacking libgcrypt20:loong64...
I: Unpacking libgnutls30:loong64...
I: Unpacking libgpg-error0:loong64...
I: Unpacking libidn2-0:loong64...
I: Unpacking libmount1:loong64...
I: Unpacking libp11-kit0:loong64...
I: Unpacking libseccomp2:loong64...
I: Unpacking libselinux1:loong64...
I: Unpacking libsemanage2:loong64...
I: Unpacking libsmartcols1:loong64...
I: Unpacking libstdc++6:loong64...
I: Unpacking libsystemd0:loong64...
I: Unpacking libudev1:loong64...
I: Unpacking libuuid1:loong64...
I: Unpacking mount...
I: Unpacking sed...
I: Unpacking sysvinit-utils...
I: Unpacking util-linux...
I: Unpacking util-linux-extra...
I: Configuring required packages...
I: Configuring debian-archive-keyring...
I: Configuring usr-is-merged...
I: Configuring libaudit-common...
I: Configuring libsemanage-common...
I: Configuring debconf...
I: Configuring gcc-12-base:loong64...
I: Configuring tzdata...
I: Configuring ncurses-base...
I: Configuring init-system-helpers...
I: Configuring libgcc-s1:loong64...
I: Configuring libc6:loong64...
I: Configuring libudev1:loong64...
I: Configuring libffi8:loong64...
I: Configuring libmd0:loong64...
I: Configuring libxxhash0:loong64...
I: Configuring libattr1:loong64...
I: Configuring sysvinit-utils...
I: Configuring libtasn1-6:loong64...
I: Configuring debianutils...
I: Configuring mawk...
I: Configuring libdebconfclient0:loong64...
I: Configuring base-files...
I: Configuring libbz2-1.0:loong64...
I: Configuring libdb5.3:loong64...
I: Configuring libblkid1:loong64...
I: Configuring libstdc++6:loong64...
I: Configuring libtinfo6:loong64...
I: Configuring bash...
I: Configuring libzstd1:loong64...
I: Configuring liblzma5:loong64...
I: Configuring libgpg-error0:loong64...
I: Configuring liblz4-1:loong64...
I: Configuring libbrotli1:loong64...
I: Configuring libc-bin...
I: Configuring ncurses-bin...
I: Configuring libacl1:loong64...
I: Configuring libssl3:loong64...
I: Configuring libunistring2:loong64...
I: Configuring libsmartcols1:loong64...
I: Configuring libgcrypt20:loong64...
I: Configuring zlib1g:loong64...
I: Configuring libcrypt1:loong64...
I: Configuring libidn2-0:loong64...
I: Configuring libcom-err2:loong64...
I: Configuring diffutils...
I: Configuring libseccomp2:loong64...
I: Configuring libcap2:loong64...
I: Configuring hostname...
I: Configuring libcap-ng0:loong64...
I: Configuring libext2fs2:loong64...
I: Configuring libnettle8:loong64...
I: Configuring libgmp10:loong64...
I: Configuring libp11-kit0:loong64...
I: Configuring libaudit1:loong64...
I: Configuring libuuid1:loong64...
I: Configuring libss2:loong64...
I: Configuring libsepol2:loong64...
I: Configuring libpcre2-8-0:loong64...
I: Configuring logsave...
I: Configuring gpgv...
I: Configuring util-linux-extra...
I: Configuring libhogweed6:loong64...
I: Configuring e2fsprogs...
I: Configuring libsystemd0:loong64...
I: Configuring libselinux1:loong64...
I: Configuring libgnutls30:loong64...
I: Configuring libpam0g:loong64...
I: Configuring libapt-pkg6.0:loong64...
I: Configuring sed...
I: Configuring findutils...
I: Configuring libmount1:loong64...
I: Configuring libsemanage2:loong64...
I: Configuring base-passwd...
I: Configuring bsdutils...
I: Configuring tar...
I: Configuring libpam-modules-bin...
I: Configuring coreutils...
I: Configuring util-linux...
I: Configuring dpkg...
I: Configuring mount...
I: Configuring dash...
I: Configuring libpam-modules:loong64...
I: Configuring grep...
I: Configuring perl-base...
I: Configuring gzip...
I: Configuring passwd...
I: Configuring libpam-runtime...
I: Configuring login...
I: Configuring adduser...
I: Configuring apt...
I: Configuring libc-bin...
I: Unpacking the base system...
I: Unpacking debian-ports-archive-keyring...
I: Configuring the base system...
I: Configuring debian-ports-archive-keyring...
I: Base system installed successfully.
debian-ports-archive-keyring set to manually installed.
++ /opt/debuerreotype/scripts/.apt-version.sh /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs
+ aptVersion=2.6.1
+ sourcesListArgs=()
+ '[' -z '' ']'
+ '[' -z 1 ']'
+ sourcesListArgs+=(--ports)
+ dpkg --compare-versions 2.6.1 '>=' 2.3~
+ sourcesListArgs+=(--deb822)
+ sourcesListFile=/etc/apt/sources.list.d/debian.sources
+ debuerreotype-debian-sources-list --ports --deb822 --snapshot /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs unstable
+ '[' -s /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs/etc/apt/sources.list.d/debian.sources ']'
+ addGpgvIgnore=
+ excludeGpgvIgnore=
+ '[' -n '' ']'
+ '[' -s /tmp/debuerreotype.unstable.eKhW1q2jnx/gpgv-status.txt ']'
+ grep -F '[GNUPG:] EXPKEYSIG ' /tmp/debuerreotype.unstable.eKhW1q2jnx/gpgv-status.txt
+ '[' -n '' ']'
+ debuerreotype-minimizing-config /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs
+ debuerreotype-apt-get /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs update -qq
+ dpkg --compare-versions 2.6.1 '>=' 1.1~
+ debuerreotype-apt-get /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs full-upgrade -yqq
debconf: delaying package configuration, since apt-utils is not installed
(Reading database ... 4966 files and directories currently installed.)
Preparing to unpack .../ncurses-base_6.4+20230625-2_all.deb ...
Unpacking ncurses-base (6.4+20230625-2) over (6.4-4) ...
Setting up ncurses-base (6.4+20230625-2) ...
+ dpkg --compare-versions 2.6.1 '>=' 0.7.14~
+ noInstallRecommends=--no-install-recommends
+ '[' -n '' ']'
+ mkdir /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim
+ tar -cC /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs .
+ tar -xC /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim
++ date --date '2021-01-01 00:00:00' +%s
+ epoch2021=1609459200
+ '[' 1701648000 -lt 1609459200 ']'
++ '[' -f /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs/etc/os-release ']'
++ source /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs/etc/os-release
+++ PRETTY_NAME='Debian GNU/Linux 12 (bookworm)'
+++ NAME='Debian GNU/Linux'
+++ VERSION_ID=12
+++ VERSION='12 (bookworm)'
+++ VERSION_CODENAME=bookworm
+++ ID=debian
+++ HOME_URL=https://www.debian.org/
+++ SUPPORT_URL=https://www.debian.org/support
+++ BUG_REPORT_URL=https://bugs.debian.org/
++ '[' -n 12 ']'
++ '[' 12 -le 10 ']'
+ isDebianBusterOrOlder=
+ debuerreotype-slimify /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim
++ _sanitize_basename /etc/apt/sources.list.d/debian.sources
++ local f=/etc/apt/sources.list.d/debian.sources
++ shift
+++ basename /etc/apt/sources.list.d/debian.sources
++ f=debian.sources
+++ sed -r -e 's/[^a-zA-Z0-9_-]+/-/g'
++ f=debian-sources
++ echo debian-sources
+ sourcesListBase=debian-sources
+ for rootfs in "$rootfsDir"*/
+ rootfs=/tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim
+ du -hsx /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim
168M	/tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim
++ basename /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim
+ variant=rootfs-slim
+ variant=-slim
+ variant=slim
+ variantDir=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim
+ mkdir -p /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim
+ targetBase=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs
+ create_artifacts /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim unstable slim
+ local targetBase=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs
+ shift
+ local rootfs=/tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim
+ shift
+ local suite=unstable
+ shift
+ local variant=slim
+ shift
+ cp /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim/etc/apt/sources.list.d/debian.sources /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian-sources-snapshot
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian-sources-snapshot
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian-sources-snapshot
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian-sources-snapshot
+ '[' 0 -gt 0 ']'
+ debuerreotype-debian-sources-list --ports --deb822 /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim unstable
+ tarArgs=('--exclude' './etc/machine-id')
+ local tarArgs
+ case "$suite" in
+ '[' '!' -e /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim/usr/share/doc/usr-is-merged/copyright ']'
+ '[' -n '' ']'
+ debuerreotype-tar --exclude ./etc/machine-id /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.tar.xz
+ du -hsx /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.tar.xz
21M	/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.tar.xz
+ sha256sum /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.tar.xz
+ cut '-d ' -f1
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.tar.xz.sha256
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.tar.xz.sha256
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.tar.xz.sha256
+ '[' 0 -gt 0 ']'
+ debuerreotype-chroot /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim bash -c '
		if ! dpkg-query -W 2> /dev/null; then
			# --debian-eol woody has no dpkg-query
			dpkg -l
		fi
	'
+ echo unstable
+ echo loong64
+ echo 1701648000
+ echo slim
+ debuerreotype-version
++ debootstrap --version
+ debootstrapVersion='debootstrap 1.0.133'
+ debootstrapVersion=1.0.133
+ echo 1.0.133
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.manifest /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.apt-dist /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.dpkg-arch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debuerreotype-epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debuerreotype-variant /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debuerreotype-version /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debootstrap-version
+ '[' 7 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.manifest
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.manifest
+ '[' 6 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.apt-dist
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.apt-dist
+ '[' 5 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.dpkg-arch
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.dpkg-arch
+ '[' 4 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debuerreotype-epoch
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debuerreotype-epoch
+ '[' 3 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debuerreotype-variant
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debuerreotype-variant
+ '[' 2 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debuerreotype-version
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debuerreotype-version
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debootstrap-version
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debootstrap-version
+ '[' 0 -gt 0 ']'
+ for f in /etc/debian_version /etc/os-release "$sourcesListFile"
++ _sanitize_basename /etc/debian_version
++ local f=/etc/debian_version
++ shift
+++ basename /etc/debian_version
++ f=debian_version
+++ sed -r -e 's/[^a-zA-Z0-9_-]+/-/g'
++ f=debian_version
++ echo debian_version
+ targetFile=debian_version
+ targetFile=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian_version
+ '[' -e /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim/etc/debian_version ']'
+ cp /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim/etc/debian_version /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian_version
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian_version
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian_version
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian_version
+ '[' 0 -gt 0 ']'
+ for f in /etc/debian_version /etc/os-release "$sourcesListFile"
++ _sanitize_basename /etc/os-release
++ local f=/etc/os-release
++ shift
+++ basename /etc/os-release
++ f=os-release
+++ sed -r -e 's/[^a-zA-Z0-9_-]+/-/g'
++ f=os-release
++ echo os-release
+ targetFile=os-release
+ targetFile=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.os-release
+ '[' -e /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim/etc/os-release ']'
+ cp /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim/etc/os-release /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.os-release
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.os-release
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.os-release
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.os-release
+ '[' 0 -gt 0 ']'
+ for f in /etc/debian_version /etc/os-release "$sourcesListFile"
++ _sanitize_basename /etc/apt/sources.list.d/debian.sources
++ local f=/etc/apt/sources.list.d/debian.sources
++ shift
+++ basename /etc/apt/sources.list.d/debian.sources
++ f=debian.sources
+++ sed -r -e 's/[^a-zA-Z0-9_-]+/-/g'
++ f=debian-sources
++ echo debian-sources
+ targetFile=debian-sources
+ targetFile=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian-sources
+ '[' -e /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim/etc/apt/sources.list.d/debian.sources ']'
+ cp /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs-slim/etc/apt/sources.list.d/debian.sources /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian-sources
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian-sources
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian-sources
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/slim/rootfs.debian-sources
+ '[' 0 -gt 0 ']'
+ for rootfs in "$rootfsDir"*/
+ rootfs=/tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs
+ du -hsx /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs
211M	/tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs
++ basename /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs
+ variant=rootfs
+ variant=
+ variant=
+ variantDir=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/
+ mkdir -p /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable/
+ targetBase=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs
+ create_artifacts /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs unstable ''
+ local targetBase=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs
+ shift
+ local rootfs=/tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs
+ shift
+ local suite=unstable
+ shift
+ local variant=
+ shift
+ cp /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs/etc/apt/sources.list.d/debian.sources /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian-sources-snapshot
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian-sources-snapshot
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian-sources-snapshot
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian-sources-snapshot
+ '[' 0 -gt 0 ']'
+ debuerreotype-debian-sources-list --ports --deb822 /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs unstable
+ tarArgs=('--exclude' './etc/machine-id')
+ local tarArgs
+ case "$suite" in
+ '[' '!' -e /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs/usr/share/doc/usr-is-merged/copyright ']'
+ '[' -n '' ']'
+ debuerreotype-tar --exclude ./etc/machine-id /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.tar.xz
+ du -hsx /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.tar.xz
33M	/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.tar.xz
+ sha256sum /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.tar.xz
+ cut '-d ' -f1
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.tar.xz.sha256
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.tar.xz.sha256
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.tar.xz.sha256
+ '[' 0 -gt 0 ']'
+ debuerreotype-chroot /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs bash -c '
		if ! dpkg-query -W 2> /dev/null; then
			# --debian-eol woody has no dpkg-query
			dpkg -l
		fi
	'
+ echo unstable
+ echo loong64
+ echo 1701648000
+ echo ''
+ debuerreotype-version
++ debootstrap --version
+ debootstrapVersion='debootstrap 1.0.133'
+ debootstrapVersion=1.0.133
+ echo 1.0.133
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.manifest /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.apt-dist /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.dpkg-arch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debuerreotype-epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debuerreotype-variant /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debuerreotype-version /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debootstrap-version
+ '[' 7 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.manifest
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.manifest
+ '[' 6 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.apt-dist
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.apt-dist
+ '[' 5 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.dpkg-arch
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.dpkg-arch
+ '[' 4 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debuerreotype-epoch
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debuerreotype-epoch
+ '[' 3 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debuerreotype-variant
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debuerreotype-variant
+ '[' 2 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debuerreotype-version
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debuerreotype-version
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debootstrap-version
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debootstrap-version
+ '[' 0 -gt 0 ']'
+ for f in /etc/debian_version /etc/os-release "$sourcesListFile"
++ _sanitize_basename /etc/debian_version
++ local f=/etc/debian_version
++ shift
+++ basename /etc/debian_version
++ f=debian_version
+++ sed -r -e 's/[^a-zA-Z0-9_-]+/-/g'
++ f=debian_version
++ echo debian_version
+ targetFile=debian_version
+ targetFile=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian_version
+ '[' -e /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs/etc/debian_version ']'
+ cp /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs/etc/debian_version /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian_version
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian_version
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian_version
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian_version
+ '[' 0 -gt 0 ']'
+ for f in /etc/debian_version /etc/os-release "$sourcesListFile"
++ _sanitize_basename /etc/os-release
++ local f=/etc/os-release
++ shift
+++ basename /etc/os-release
++ f=os-release
+++ sed -r -e 's/[^a-zA-Z0-9_-]+/-/g'
++ f=os-release
++ echo os-release
+ targetFile=os-release
+ targetFile=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.os-release
+ '[' -e /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs/etc/os-release ']'
+ cp /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs/etc/os-release /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.os-release
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.os-release
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.os-release
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.os-release
+ '[' 0 -gt 0 ']'
+ for f in /etc/debian_version /etc/os-release "$sourcesListFile"
++ _sanitize_basename /etc/apt/sources.list.d/debian.sources
++ local f=/etc/apt/sources.list.d/debian.sources
++ shift
+++ basename /etc/apt/sources.list.d/debian.sources
++ f=debian.sources
+++ sed -r -e 's/[^a-zA-Z0-9_-]+/-/g'
++ f=debian-sources
++ echo debian-sources
+ targetFile=debian-sources
+ targetFile=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian-sources
+ '[' -e /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs/etc/apt/sources.list.d/debian.sources ']'
+ cp /tmp/debuerreotype.unstable.eKhW1q2jnx/rootfs/etc/apt/sources.list.d/debian.sources /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian-sources
+ touch_epoch /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian-sources
+ '[' 1 -gt 0 ']'
+ local f=/tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian-sources
+ shift
+ touch --no-dereference --date=@1701648000 /tmp/debuerreotype.unstable.eKhW1q2jnx/output/20231204/loong64/unstable//rootfs.debian-sources
+ '[' 0 -gt 0 ']'
+ '[' -n '' ']'
++ stat --format %u /workdir/validate
+ user=0
++ stat --format %g /workdir/validate
+ group=0
+ tar --create --directory=/tmp/debuerreotype.unstable.eKhW1q2jnx/output --owner=0 --group=0 .
+ tar --extract --verbose --directory=/workdir/validate
./
./20231204/
./20231204/loong64/
./20231204/loong64/unstable/
./20231204/loong64/unstable/rootfs.debian-sources
./20231204/loong64/unstable/rootfs.os-release
./20231204/loong64/unstable/rootfs.debian_version
./20231204/loong64/unstable/rootfs.debootstrap-version
./20231204/loong64/unstable/rootfs.debuerreotype-version
./20231204/loong64/unstable/rootfs.debuerreotype-variant
./20231204/loong64/unstable/rootfs.debuerreotype-epoch
./20231204/loong64/unstable/rootfs.dpkg-arch
./20231204/loong64/unstable/rootfs.apt-dist
./20231204/loong64/unstable/rootfs.manifest
./20231204/loong64/unstable/rootfs.tar.xz.sha256
./20231204/loong64/unstable/rootfs.tar.xz
./20231204/loong64/unstable/rootfs.debian-sources-snapshot
./20231204/loong64/unstable/slim/
./20231204/loong64/unstable/slim/rootfs.debian-sources
./20231204/loong64/unstable/slim/rootfs.os-release
./20231204/loong64/unstable/slim/rootfs.debian_version
./20231204/loong64/unstable/slim/rootfs.debootstrap-version
./20231204/loong64/unstable/slim/rootfs.debuerreotype-version
./20231204/loong64/unstable/slim/rootfs.debuerreotype-variant
./20231204/loong64/unstable/slim/rootfs.debuerreotype-epoch
./20231204/loong64/unstable/slim/rootfs.dpkg-arch
./20231204/loong64/unstable/slim/rootfs.apt-dist
./20231204/loong64/unstable/slim/rootfs.manifest
./20231204/loong64/unstable/slim/rootfs.tar.xz.sha256
./20231204/loong64/unstable/slim/rootfs.tar.xz
./20231204/loong64/unstable/slim/rootfs.debian-sources-snapshot
./20231204/loong64/unstable/Release
./20231204/loong64/unstable/InRelease
./20231204/loong64/snapshot-url
+ rm -rf /tmp/debuerreotype.unstable.eKhW1q2jnx
++ sha256sum validate/20231204/loong64/unstable/rootfs.tar.xz
++ cut '-d ' -f1
+ real=e66ba90a44784ae16e437387b70efd47d802e3b365f923bbd0e4e2976f69057c
./.validate-debian.sh: line 36: SHA256: unbound variable
```

</details>