### PR TITLE
Skip installing iputils-ping if unavailable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
 
           - { DISTRO: ubuntu, SUITE: bionic }
           - { DISTRO: ubuntu, SUITE: focal }
+          - { DISTRO: ubuntu, SUITE: focal, ARCH: i386 }
       fail-fast: false
     name: Test ${{ matrix.DISTRO && format('{0} ', matrix.DISTRO) }}${{ matrix.SUITE }}${{ matrix.CODENAME && format(' ({0})', matrix.CODENAME) }}${{ matrix.ARCH && format(' [{0}]', matrix.ARCH) }}${{ matrix.TIMESTAMP && format(' at {0}', matrix.TIMESTAMP) }}
     runs-on: ubuntu-20.04

--- a/.validate-ubuntu.sh
+++ b/.validate-ubuntu.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+buildArgs=()
+if [ -n "${ARCH:-}" ]; then
+	buildArgs+=( "--arch=${ARCH}" )
+fi
+buildArgs+=( validate "$SUITE" )
+
 dockerImage="$(./.docker-image.sh)"
 dockerImage+='-ubuntu'
 {
@@ -21,4 +27,4 @@ mkdir -p validate
 set -x
 
 ./scripts/debuerreotype-version
-./docker-run.sh --image="$dockerImage" --no-build ./examples/ubuntu.sh validate "$SUITE"
+./docker-run.sh --image="$dockerImage" --no-build ./examples/ubuntu.sh "${buildArgs[@]}"

--- a/examples/ubuntu.sh
+++ b/examples/ubuntu.sh
@@ -137,7 +137,12 @@ if ! debuerreotype-apt-get "$rootfsDir" install -qq -s iproute2 &> /dev/null; th
 	# poor wheezy
 	iproute=iproute
 fi
-debuerreotype-apt-get "$rootfsDir" install -y --no-install-recommends iputils-ping $iproute
+ping=iputils-ping
+if ! (debuerreotype-chroot "$rootfsDir" apt-cache policy iputils-ping 2>/dev/null | grep -E '^ [ *]{3} [0-9].*'); then
+	# iputils-ping:i386 became unavailable since Focal.
+	ping=
+fi
+debuerreotype-apt-get "$rootfsDir" install -y --no-install-recommends $ping $iproute
 
 debuerreotype-slimify "$rootfsDir"-slim
 


### PR DESCRIPTION
iputils-ping is no longer available in i386 architecture since Ubuntu Focal for unknown reason.