### PR TITLE
Dockerfile: Delimit key/value with "=" instead of whitespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*
 
 # fight the tyrrany of HSTS (which destroys our ability to transparently cache snapshot.debian.org responses)
-ENV WGETRC /.wgetrc
+ENV WGETRC=/.wgetrc
 RUN echo 'hsts=0' >> "$WGETRC"
 
 # https://github.com/debuerreotype/debuerreotype/issues/100


### PR DESCRIPTION
I was running the [oneliner from README](https://github.com/debuerreotype/debuerreotype/blob/fc9630d5971f03ca871225bb0a0836109ad1a5b1/README.md#L98) when I encountered this.

I'm not familiar with how Debian is building the official images to know if this is a real problem or not, but this fixes it.

PS.: I still get an error when running the oneliner, but I don't know if the issue is in my environment and I'm investigating it. Just for reference, this is what I still get:
> Unable to find image 'debuerreotype/debuerreotype:0.16-dev' locally
> docker: Error response from daemon: {"message":"manifest unknown: manifest unknown"}.

# Commit message
Fix warning when running docker-run.sh:
> - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 29)

Ref: https://docs.docker.com/reference/build-checks/legacy-key-value-format/