### PR TITLE
Update hard-coded checksums in `Dockerfile` and `README.md`, and add CI to validate them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,15 @@ jobs:
           - { SUITE: stable,    CODENAME: "", TIMESTAMP: "today 00:00:00", SHA256: "" }
           - { SUITE: oldstable, CODENAME: "", TIMESTAMP: "today 00:00:00", SHA256: "" }
 
+          # Dockerfile checksums
+          - { DISTRO: dockerfile, SUITE: stretch, TIMESTAMP: "2017-05-08T00:00:00Z", SHA256: 7b295f07692e13e3aaec0709e38f5fbfe3b7153d024c556430be70fd845fc174 }
+          - { DISTRO: dockerfile, SUITE: jessie,  TIMESTAMP: "2017-05-08T00:00:00Z", SHA256: 5d1daeb8e817a56d28b65b4fa5eb09ebb1963299a0ccfd2a37c07560779653cd }
+          # README.md checksum
+          - { DISTRO: readme,     SUITE: stretch, TIMESTAMP: "2017-01-01T00:00:00Z", SHA256: ac026b83d085e1e516e21865a92c443529119264a302bcefc60f0a8613e922ad }
+
           # smoke test Ubuntu 24.04 and 22.04
-          - { DISTRO: ubuntu, SUITE: noble }
-          - { DISTRO: ubuntu, SUITE: jammy }
+          - { DISTRO: ubuntu, SUITE: noble, SHA256: "" }
+          - { DISTRO: ubuntu, SUITE: jammy, SHA256: "" }
       fail-fast: false
     name: Test ${{ matrix.DISTRO && format('{0} ', matrix.DISTRO) }}${{ matrix.SUITE }}${{ matrix.CODENAME && format(' ({0})', matrix.CODENAME) }}${{ matrix.ARCH && format(' [{0}]', matrix.ARCH) }}${{ matrix.TIMESTAMP && format(' at {0}', matrix.TIMESTAMP) }}
     runs-on: ubuntu-24.04

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "validate"]
 	path = validate
 	url = https://github.com/debuerreotype/validation-artifacts.git
-	branch = 2025-08-11
+	branch = 2025-08-29

--- a/.validate-dockerfile.sh
+++ b/.validate-dockerfile.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+mkdir -p validate/dockerfile
+
+./docker-run.sh --pull bash -Eeuo pipefail -c '
+	export SUITE="$1" TIMESTAMP="$2"
+	dir="validate/dockerfile"
+	user="$(stat --format "%u" "$dir")"
+	group="$(stat --format "%g" "$dir")"
+
+	debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.pgp --no-merged-usr /tmp/rootfs "$SUITE" "$TIMESTAMP"
+
+	debuerreotype-tar /tmp/rootfs "$dir/$SUITE.tar.xz"
+
+	chown "$user:$group" "$dir/$SUITE.tar.xz"
+' -- "$SUITE" "$TIMESTAMP"
+
+xz --threads=0 --decompress < "validate/dockerfile/$SUITE.tar.xz" | sha256sum | cut -d' ' -f1 > "validate/dockerfile/$SUITE.tar.sha256"

--- a/.validate-readme.sh
+++ b/.validate-readme.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+mkdir -p validate/readme
+
+./docker-run.sh --pull bash -Eeuo pipefail -c '
+	export SUITE="$1" TIMESTAMP="$2"
+	dir="validate/readme"
+	user="$(stat --format "%u" "$dir")"
+	group="$(stat --format "%g" "$dir")"
+
+	debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.pgp --no-merged-usr /tmp/rootfs "$SUITE" "$TIMESTAMP"
+
+	debuerreotype-minimizing-config /tmp/rootfs
+
+	debuerreotype-apt-get /tmp/rootfs update -qq
+
+	debuerreotype-apt-get /tmp/rootfs dist-upgrade -yqq
+
+	debuerreotype-apt-get /tmp/rootfs install -yqq --no-install-recommends inetutils-ping iproute2
+
+	debuerreotype-debian-sources-list /tmp/rootfs "$SUITE"
+
+	debuerreotype-tar /tmp/rootfs "$dir/$SUITE.tar.xz"
+
+	chown "$user:$group" "$dir/$SUITE.tar.xz"
+' -- "$SUITE" "$TIMESTAMP"
+
+xz --threads=0 --decompress < "validate/readme/$SUITE.tar.xz" | sha256sum | cut -d' ' -f1 > "validate/readme/$SUITE.tar.sha256"

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,18 +69,17 @@ RUN set -eux; \
 
 WORKDIR /tmp
 
-# a few example md5sum values for amd64:
 
-# TODO update these examples, because they don't actually work anymore 😭
+# a few example sha256sum values for amd64:
 
-# debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.gpg test-stretch stretch 2017-05-08T00:00:00Z
+# debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.pgp --no-merged-usr test-stretch stretch 2017-05-08T00:00:00Z
 # debuerreotype-tar test-stretch test-stretch.tar
-# md5sum test-stretch.tar
-#   694f02c53651673ebe094cae3bcbb06d
-# ./docker-run.sh sh -euxc 'debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.gpg /tmp/rootfs stretch 2017-05-08T00:00:00Z; debuerreotype-tar /tmp/rootfs - | md5sum'
+# sha256sum test-stretch.tar
+#   7b295f07692e13e3aaec0709e38f5fbfe3b7153d024c556430be70fd845fc174
+# ./docker-run.sh sh -euxc 'debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.pgp --no-merged-usr /tmp/rootfs stretch 2017-05-08T00:00:00Z; debuerreotype-tar /tmp/rootfs - | sha256sum'
 
-# debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.gpg test-jessie jessie 2017-05-08T00:00:00Z
+# debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.pgp --no-merged-usr test-jessie jessie 2017-05-08T00:00:00Z
 # debuerreotype-tar test-jessie test-jessie.tar
-# md5sum test-jessie.tar
-#   354cedd99c08d213d3493a7cf0aaaad6
-# ./docker-run.sh sh -euxc 'debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.gpg /tmp/rootfs jessie 2017-05-08T00:00:00Z; debuerreotype-tar /tmp/rootfs - | md5sum'
+# sha256sum test-jessie.tar
+#   5d1daeb8e817a56d28b65b4fa5eb09ebb1963299a0ccfd2a37c07560779653cd
+# ./docker-run.sh sh -euxc 'debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.pgp --no-merged-usr /tmp/rootfs jessie 2017-05-08T00:00:00Z; debuerreotype-tar /tmp/rootfs - | sha256sum'

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Processing triggers for libc-bin (2.24-8) ...
 $ debuerreotype-debian-sources-list rootfs stretch
 
 $ debuerreotype-tar rootfs - | sha256sum
-e6f10da22f7ab5996f855c85ad5ae38cd786029c57893436c3bb2320f30bc188  -
+ac026b83d085e1e516e21865a92c443529119264a302bcefc60f0a8613e922ad  -
 
 $ # try it!  you should get that same sha256sum value!
 ```


### PR DESCRIPTION
This also stores the verbatim artifacts so that monitoring change-over-time is easier like all our other validation now has:

https://github.com/debuerreotype/validation-artifacts/compare/f89e6a3db51bc0f367bbef74f17001f5e508e96a..bbc7e73f82b41312ceb4a5c5810eadbf8b8aee73