### PR TITLE
Add `ulimit` workarounds when building Jessie

### DIFF
--- a/.validate-dockerfile.sh
+++ b/.validate-dockerfile.sh
@@ -9,6 +9,13 @@ mkdir -p validate/dockerfile
 	user="$(stat --format "%u" "$dir")"
 	group="$(stat --format "%g" "$dir")"
 
+	if [ "$SUITE" = jessie ]; then
+		# https://bugs.debian.org/764204 "apt-cache calls fcntl() on 65536 FDs"
+		# https://bugs.launchpad.net/bugs/1332440 "apt-get update very slow when ulimit -n is big"
+		ulimit -n 1024
+		# (see also "examples/debian.sh")
+	fi
+
 	debuerreotype-init --keyring /usr/share/keyrings/debian-archive-removed-keys.pgp --no-merged-usr /tmp/rootfs "$SUITE" "$TIMESTAMP"
 
 	debuerreotype-tar /tmp/rootfs "$dir/$SUITE.tar.xz"

--- a/examples/debian.sh
+++ b/examples/debian.sh
@@ -182,6 +182,13 @@ if [ -n "$codenameCopy" ] && [ -z "$codename" ]; then
 	exit 1
 fi
 
+if [ "${codename:-$suite}" = 'jessie' ]; then
+	# https://bugs.debian.org/764204 "apt-cache calls fcntl() on 65536 FDs"
+	# https://bugs.launchpad.net/bugs/1332440 "apt-get update very slow when ulimit -n is big"
+	ulimit -n 1024
+	# I contemplated/played with adding this to "debuerreotype-apt-get" instead with a test on aptVersion >= 1.0.9.2 and < 1.1~exp9 (for safety), but it's really needed during debootstrap too ("Configuring apt" / "Setting up apt" hangs), and jessie is the only Debian release affected, so this is a simpler/cleaner test anyhow
+fi
+
 # apply merged-/usr (for bookworm+)
 # https://lists.debian.org/debian-ctte/2022/07/msg00034.html
 # https://github.com/debuerreotype/docker-debian-artifacts/issues/131#issuecomment-1190233249


### PR DESCRIPTION
- https://bugs.debian.org/764204 "apt-cache calls fcntl() on 65536 FDs"
- https://bugs.launchpad.net/bugs/1332440 "apt-get update very slow when ulimit -n is big"