### PR TITLE
Reduce autodetection by leaning into the `DEBUERREOTYPE_DIRECTORY` interface in explicit `examples` scripts

### DIFF
--- a/examples/debian-all.sh
+++ b/examples/debian-all.sh
@@ -12,11 +12,7 @@ suites=(
 	oldoldoldstable
 )
 
-debuerreotypeScriptsDir="$(which debuerreotype-init)"
-debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
-debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
-
-source "$debuerreotypeScriptsDir/.constants.sh" \
+source "$DEBUERREOTYPE_DIRECTORY/scripts/.constants.sh" \
 	--flags 'arch:' \
 	--flags 'dry-run' \
 	-- \
@@ -42,17 +38,14 @@ timestamp="${1:-}"; shift || eusage 'missing timestamp'
 
 debianArgs=( --codename-copy )
 
-mirror="$("$debuerreotypeScriptsDir/.snapshot-url.sh" "$timestamp")"
-secmirror="$("$debuerreotypeScriptsDir/.snapshot-url.sh" "$timestamp" 'debian-security')"
+mirror="$("$DEBUERREOTYPE_DIRECTORY/scripts/.snapshot-url.sh" "$timestamp")"
+secmirror="$("$DEBUERREOTYPE_DIRECTORY/scripts/.snapshot-url.sh" "$timestamp" 'debian-security')"
 
 dpkgArch="${arch:-$(dpkg --print-architecture | awk -F- '{ print $NF }')}"
 echo
 echo "-- BUILDING TARBALLS FOR '$dpkgArch' FROM '$mirror/' --"
 echo
 debianArgs+=( --arch="$dpkgArch" )
-
-thisDir="$(readlink -vf "$BASH_SOURCE")"
-thisDir="$(dirname "$thisDir")"
 
 _eol-date() {
 	local codename="$1"; shift # "bullseye", "buster", etc.
@@ -163,7 +156,7 @@ for suite in "${suites[@]}"; do
 		echo >&2
 		continue
 	fi
-	cmd=( "$thisDir/debian.sh" "${debianArgs[@]}" "$outputDir" "$suite" "$timestamp" )
+	cmd=( "$DEBUERREOTYPE_DIRECTORY/examples/debian.sh" "${debianArgs[@]}" "$outputDir" "$suite" "$timestamp" )
 	if [ -n "$dryRun" ]; then
 		printf 'DRY-RUN: $'
 		printf ' %q' "${cmd[@]}"

--- a/examples/debian.sh
+++ b/examples/debian.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-debuerreotypeScriptsDir="$(which debuerreotype-init)"
-debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
-debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
-
-source "$debuerreotypeScriptsDir/.constants.sh" \
+source "$DEBUERREOTYPE_DIRECTORY/scripts/.constants.sh" \
 	--flags 'codename-copy' \
 	--flags 'eol,ports' \
 	--flags 'arch:' \
@@ -77,7 +73,7 @@ for archive in '' security; do
 		mirrorArgs+=( --eol )
 	fi
 	mirrorArgs+=( "@$epoch" "$suite${archive:+-$archive}" "$dpkgArch" main )
-	if ! mirrors="$("$debuerreotypeScriptsDir/.debian-mirror.sh" "${mirrorArgs[@]}")"; then
+	if ! mirrors="$("$DEBUERREOTYPE_DIRECTORY/scripts/.debian-mirror.sh" "${mirrorArgs[@]}")"; then
 		if [ "$archive" = 'security' ]; then
 			# if we fail to find the security mirror, we're probably not security supported (which is ~fine)
 			continue
@@ -228,7 +224,7 @@ fi
 rootfsDir="$tmpDir/rootfs"
 debuerreotype-init "${initArgs[@]}" "$rootfsDir" "$suite" "@$epoch"
 
-aptVersion="$("$debuerreotypeScriptsDir/.apt-version.sh" "$rootfsDir")"
+aptVersion="$("$DEBUERREOTYPE_DIRECTORY/scripts/.apt-version.sh" "$rootfsDir")"
 
 # regenerate sources.list to make the deb822/line-based opinion explicit
 # https://lists.debian.org/debian-devel/2021/11/msg00026.html

--- a/examples/oci-image.sh
+++ b/examples/oci-image.sh
@@ -9,18 +9,7 @@ set -Eeuo pipefail
 # 	&& apt-get install -y jq pigz \
 # 	&& rm -rf /var/lib/apt/lists/*
 
-thisDir="$(readlink -vf "$BASH_SOURCE")"
-thisDir="$(dirname "$thisDir")"
-
-if [ -x "$thisDir/../scripts/debuerreotype-init" ]; then
-	debuerreotypeScriptsDir="$(dirname "$thisDir")/scripts"
-else
-	debuerreotypeScriptsDir="$(which debuerreotype-init)"
-	debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
-	debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
-fi
-
-source "$debuerreotypeScriptsDir/.constants.sh" \
+source "$DEBUERREOTYPE_DIRECTORY/scripts/.constants.sh" \
 	--flags 'meta:' \
 	-- \
 	'<target-file.tar> <source-directory>' \
@@ -109,7 +98,7 @@ mv "$tempDir/rootfs.tar.gz" "$tempDir/oci/blobs/rootfs.tar.gz"
 ln -sfT ../rootfs.tar.gz "$tempDir/oci/blobs/sha256/$rootfsSha256"
 
 script='debian.sh'
-if [ -x "$thisDir/$osID.sh" ]; then
+if [ -x "$DEBUERREOTYPE_DIRECTORY/examples/$osID.sh" ]; then
 	script="$osID.sh"
 fi
 export script

--- a/examples/raspbian.sh
+++ b/examples/raspbian.sh
@@ -6,11 +6,7 @@ set -Eeuo pipefail
 # 	&& apt-get install -y ./raspbian.deb \
 # 	&& rm raspbian.deb
 
-debuerreotypeScriptsDir="$(which debuerreotype-init)"
-debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
-debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
-
-source "$debuerreotypeScriptsDir/.constants.sh" \
+source "$DEBUERREOTYPE_DIRECTORY/scripts/.constants.sh" \
 	-- \
 	'<output-dir> <suite>' \
 	'output stretch'
@@ -141,7 +137,7 @@ touch_epoch() {
 	done
 }
 
-aptVersion="$("$debuerreotypeScriptsDir/.apt-version.sh" "$rootfsDir")"
+aptVersion="$("$DEBUERREOTYPE_DIRECTORY/scripts/.apt-version.sh" "$rootfsDir")"
 if dpkg --compare-versions "$aptVersion" '>=' '1.1~'; then
 	debuerreotype-apt-get "$rootfsDir" full-upgrade -yqq
 else

--- a/examples/steamos.sh
+++ b/examples/steamos.sh
@@ -6,11 +6,7 @@ set -Eeuo pipefail
 # 	&& apt-get install -y ./valve.deb \
 # 	&& rm valve.deb
 
-debuerreotypeScriptsDir="$(which debuerreotype-init)"
-debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
-debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
-
-source "$debuerreotypeScriptsDir/.constants.sh" \
+source "$DEBUERREOTYPE_DIRECTORY/scripts/.constants.sh" \
 	--flags 'arch:' \
 	-- \
 	'[--arch=<arch>] <output-dir> <suite>' \
@@ -116,7 +112,7 @@ touch_epoch() {
 }
 touch_epoch "$rootfsDir/etc/apt/sources.list"
 
-aptVersion="$("$debuerreotypeScriptsDir/.apt-version.sh" "$rootfsDir")"
+aptVersion="$("$DEBUERREOTYPE_DIRECTORY/scripts/.apt-version.sh" "$rootfsDir")"
 if dpkg --compare-versions "$aptVersion" '>=' '1.1~'; then
 	debuerreotype-apt-get "$rootfsDir" full-upgrade -yqq
 else

--- a/examples/ubuntu.sh
+++ b/examples/ubuntu.sh
@@ -5,11 +5,7 @@ set -Eeuo pipefail
 # 	&& apt-get install -y ubuntu-keyring \
 # 	&& rm -rf /var/lib/apt/lists/*
 
-debuerreotypeScriptsDir="$(which debuerreotype-init)"
-debuerreotypeScriptsDir="$(readlink -vf "$debuerreotypeScriptsDir")"
-debuerreotypeScriptsDir="$(dirname "$debuerreotypeScriptsDir")"
-
-source "$debuerreotypeScriptsDir/.constants.sh" \
+source "$DEBUERREOTYPE_DIRECTORY/scripts/.constants.sh" \
 	--flags 'arch:' \
 	-- \
 	'[--arch=<arch>] <output-dir> <suite>' \
@@ -126,7 +122,7 @@ touch_epoch() {
 }
 touch_epoch "$rootfsDir/etc/apt/sources.list"
 
-aptVersion="$("$debuerreotypeScriptsDir/.apt-version.sh" "$rootfsDir")"
+aptVersion="$("$DEBUERREOTYPE_DIRECTORY/scripts/.apt-version.sh" "$rootfsDir")"
 if dpkg --compare-versions "$aptVersion" '>=' '1.1~'; then
 	debuerreotype-apt-get "$rootfsDir" full-upgrade -yqq
 else


### PR DESCRIPTION
We still do autodetection in `scripts/*` and top-level scripts (`.docker-image.sh` and `docker-run.sh`), but this makes at least the `examples` scripts cleaner.