### PR TITLE
Autodetect default image command (`bash` with `sh` fallback)

### DIFF
--- a/examples/oci-image.sh
+++ b/examples/oci-image.sh
@@ -83,6 +83,19 @@ xz --decompress --threads=0 --stdout "$sourceDir/rootfs.tar.xz" > "$tempDir/root
 diffId="$(_sha256 "$tempDir/rootfs.tar")"
 export diffId="sha256:$diffId"
 
+# detect an appropriate interactive command based on what exists
+# (https://salsa.debian.org/debian/grow-your-ideas/-/issues/20)
+cmd=
+for cmdPotential in bash sh; do
+	for cmdPotentialFile in "bin/$cmdPotential" "usr/bin/$cmdPotential" "usr/local/bin/$cmdPotential"; do
+		if tar -tf "$tempDir/rootfs.tar" "$cmdPotentialFile" &> /dev/null; then
+			cmd="$cmdPotential"
+			break 2
+		fi
+	done
+done
+export cmd
+
 echo >&2 "recompressing rootfs (gzip) ..."
 
 pigz --best --no-time "$tempDir/rootfs.tar"
@@ -106,7 +119,7 @@ jq --null-input --compact-output '
 		config: {
 			Env: [ "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" ],
 			Entrypoint: [],
-			Cmd: [ "bash" ],
+			Cmd: [ if env.cmd != "" then env.cmd else empty end ],
 		},
 		created: env.iso8601,
 		history: [


### PR DESCRIPTION
There's an off-and-on attempt within Debian to remove `bash` from the minimal install (https://salsa.debian.org/debian/grow-your-ideas/-/issues/20).  While I don't necessarily agree that `bash` is the best fruit to try and trim from the tree, I figured it's worth finally pushing up the implementation I wrote up that could support that in case it does eventually happen.