### PR TITLE
Fix bindmount in unprivileged usernses by setting locked flags

### DIFF
--- a/scripts/debuerreotype-chroot
+++ b/scripts/debuerreotype-chroot
@@ -32,7 +32,7 @@ unshare --mount bash -Eeuo pipefail -c '
 		fi
 	done
 	if [ -f "$targetDir/etc/resolv.conf" ]; then
-		mount --rbind --read-only /etc/resolv.conf "$targetDir/etc/resolv.conf"
+		mount --bind -o ro,nosuid,noexec,nodev /etc/resolv.conf "$targetDir/etc/resolv.conf"
 	fi
 	exec chroot "$targetDir" /usr/bin/env -i \
 		PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \


### PR DESCRIPTION
On my computer at least, the command in question is failing with EPERM because it attempts to unset nosuid, noexec and nodev from (the bind-mounted copy of) /etc/resolv.conf, which is not allowed in an unprivileged userns. Fix by adding those flags as mount options.

AFAIK it's permissible to set those flags, but not unset them, inside an unprivileged userns. And /etc/resolv.conf inside the chroot doesn't need to be suid, executable or a device node anyway.